### PR TITLE
Add ADTOF drum transcription to the MIDI pipeline

### DIFF
--- a/backend/api/midi.py
+++ b/backend/api/midi.py
@@ -82,7 +82,7 @@ STEM_DEFAULT_PROGRAM: dict[str, int] = {
     "other": 48,        # String Ensemble 1
 }
 
-STEM_IS_DRUM: dict[str, bool] = {label: True for label in DRUM_STEM_LABELS}
+STEM_IS_DRUM: dict[str, bool] = dict.fromkeys(DRUM_STEM_LABELS, True)
 
 # ─── SoundFont discovery & state ─────────────────────────────────────────
 

--- a/backend/api/midi.py
+++ b/backend/api/midi.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from backend.services.job_manager import job_manager
 from backend.services.session_store import SessionStore, TrackState, get_user_session
 from backend.services import pipeline_manager
+from utils.midi_io import DRUM_STEM_LABELS
 from utils.paths import MIDI_DIR
 
 router = APIRouter(prefix="/api/midi", tags=["midi"])
@@ -81,10 +82,7 @@ STEM_DEFAULT_PROGRAM: dict[str, int] = {
     "other": 48,        # String Ensemble 1
 }
 
-STEM_IS_DRUM: dict[str, bool] = {
-    "drums": True,
-    "Drums & percussion": True,
-}
+STEM_IS_DRUM: dict[str, bool] = {label: True for label in DRUM_STEM_LABELS}
 
 # ─── SoundFont discovery & state ─────────────────────────────────────────
 

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -91,7 +91,7 @@ def capabilities() -> dict:
 def list_models() -> dict:
     from models.registry import (
         list_specs, DemucsSpec, RoformerSpec, BasicPitchSpec,
-        WhisperSpec, StableAudioSpec,
+        DrumMidiSpec, WhisperSpec, StableAudioSpec,
     )
 
     def _serialize(spec) -> dict:
@@ -111,6 +111,7 @@ def list_models() -> dict:
         "demucs": [_serialize(s) for s in list_specs(DemucsSpec)],
         "roformer": [_serialize(s) for s in list_specs(RoformerSpec)],
         "basicpitch": [_serialize(s) for s in list_specs(BasicPitchSpec)],
+        "drum_midi": [_serialize(s) for s in list_specs(DrumMidiSpec)],
         "whisper": [_serialize(s) for s in list_specs(WhisperSpec)],
         "stable_audio": [_serialize(s) for s in list_specs(StableAudioSpec)],
     }

--- a/frontend/components/midi.js
+++ b/frontend/components/midi.js
@@ -55,6 +55,9 @@ export function initMidi() {
     el('div', { className: 'checkbox-group', id: 'midi-stems' },
       el('span', { className: 'text-dim' }, 'Run separation first'),
     ),
+    el('div', { className: 'text-dim hidden', id: 'midi-drum-hint' },
+      'Drum stems use ADTOF drum transcription (kick, snare, tom, hi-hat, cymbal → GM drum kit).',
+    ),
   );
 
   const keyGroup = el('div', { className: 'form-group' },
@@ -289,6 +292,9 @@ export function initMidi() {
   });
   document.getElementById('midi-start').addEventListener('click', startExtraction);
 
+  // Show the drum transcription hint whenever a drum stem is checked
+  document.getElementById('midi-stems').addEventListener('change', syncDrumHint);
+
   // Import MIDI file
   document.getElementById('midi-import').addEventListener('click', () => {
     document.getElementById('midi-import-input').click();
@@ -402,6 +408,13 @@ function populateStemCheckboxes(stemPaths) {
       ),
     );
   }
+  syncDrumHint();
+}
+
+function syncDrumHint() {
+  const checked = document.querySelectorAll('#midi-stems input[type="checkbox"]:checked');
+  const hasDrum = Array.from(checked).some(cb => isDrumStem(cb.value));
+  document.getElementById('midi-drum-hint').classList.toggle('hidden', !hasDrum);
 }
 
 async function startExtraction() {

--- a/models/adtof_loader.py
+++ b/models/adtof_loader.py
@@ -1,0 +1,155 @@
+"""
+ADTOF drum transcription model loader for StemForge.
+
+Wraps the ADTOF-pytorch Frame-RNN model (``xavriley/ADTOF-pytorch``) for
+automatic drum transcription.  The model emits per-frame activations for
+five drum classes; peak picking converts these to onset times, and each
+class maps directly to a General MIDI percussion note (the library's
+``LABELS_5`` is already the GM note list: kick 35, snare 38, tom 47,
+hi-hat 42, cymbal 49).
+
+Weights ship inside the pip package — nothing is downloaded at runtime.
+Input audio of any sample rate is accepted; the library resamples to
+44.1 kHz internally via librosa.
+"""
+
+import logging
+import pathlib
+
+import torch
+
+from utils.device import get_device
+from utils.errors import ModelLoadError, PipelineExecutionError
+from utils.midi_io import NoteEvent
+
+log = logging.getLogger("stemforge.models.adtof_loader")
+
+# Percussion hits have no meaningful sustain — every event gets this length,
+# matching the 60 ms drum cap in utils.midi_io.notes_to_midi().
+NOTE_DURATION_S: float = 0.06
+
+# ADTOF activations carry no amplitude information usable as velocity.
+DEFAULT_VELOCITY: int = 100
+
+
+class AdtofModelLoader:
+    """Loads the ADTOF Frame-RNN model and transcribes drum audio.
+
+    Lifecycle mirrors the other StemForge loaders::
+
+        loader = AdtofModelLoader()
+        loader.load()
+        events = loader.predict(path)
+        loader.evict()
+    """
+
+    def __init__(self) -> None:
+        self._model: torch.nn.Module | None = None
+        self._device: torch.device | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def load(self) -> torch.nn.Module:
+        """Load the Frame-RNN weights onto the best available device.
+
+        Idempotent: if already loaded, returns the cached instance.
+
+        Raises
+        ------
+        :class:`~utils.errors.ModelLoadError`
+            If adtof-pytorch is not installed or the weights cannot be
+            deserialised.
+        """
+        if self._model is not None:
+            return self._model
+        try:
+            import adtof_pytorch
+
+            model = adtof_pytorch.create_frame_rnn_model(
+                adtof_pytorch.calculate_n_bins()
+            )
+            model.eval()
+            weights_path = adtof_pytorch.get_default_weights_path()
+            model = adtof_pytorch.load_pytorch_weights(
+                model, str(weights_path), strict=False
+            )
+            self._device = get_device()
+            model.to(self._device)
+            self._model = model
+        except Exception as exc:
+            raise ModelLoadError(
+                f"Could not load ADTOF drum model: {exc}",
+                model_name="adtof-drums",
+            ) from exc
+        log.info("AdtofModelLoader: model ready on %s.", self._device)
+        return self._model
+
+    @property
+    def is_loaded(self) -> bool:
+        """``True`` if the model is currently in memory."""
+        return self._model is not None
+
+    def evict(self) -> None:
+        """Release the model from memory.  Safe to call when not loaded."""
+        if self._model is None:
+            return
+        self._model = None
+        if self._device is not None and self._device.type == "cuda":
+            torch.cuda.empty_cache()
+        self._device = None
+        log.debug("AdtofModelLoader: model evicted.")
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    def predict(self, path: pathlib.Path) -> list[NoteEvent]:
+        """Transcribe a drum stem to GM percussion note events.
+
+        Parameters
+        ----------
+        path:
+            Drum audio file.  Any sample rate; resampled internally.
+
+        Returns
+        -------
+        list[NoteEvent]
+            ``(start_sec, end_sec, gm_note, velocity)`` tuples sorted by
+            start time.  Pitches are GM channel-10 percussion notes.
+
+        Raises
+        ------
+        :class:`~utils.errors.ModelLoadError`
+            If the model is not loaded and cannot be loaded on demand.
+        :class:`~utils.errors.PipelineExecutionError`
+            If the forward pass or peak picking fails.
+        """
+        if self._model is None:
+            self.load()
+
+        try:
+            from adtof_pytorch import PeakPicker, load_audio_for_model
+
+            x = load_audio_for_model(str(path)).to(self._device)
+            with torch.no_grad():
+                activations = self._model(x).cpu().numpy()
+
+            # Defaults are the library's trained per-class thresholds and
+            # 100 fps frame rate; pick() returns {gm_note: [onset_sec, ...]}.
+            peaks = PeakPicker().pick(activations)[0]
+        except Exception as exc:
+            raise PipelineExecutionError(
+                f"Drum transcription failed for '{path.name}': {exc}",
+                pipeline_name="midi",
+            ) from exc
+
+        events: list[NoteEvent] = [
+            (float(onset), float(onset) + NOTE_DURATION_S, int(gm_note), DEFAULT_VELOCITY)
+            for gm_note, onsets in peaks.items()
+            for onset in onsets
+        ]
+        events.sort(key=lambda e: e[0])
+        log.debug("AdtofModelLoader: %s → %d drum events", path.name, len(events))
+        return events

--- a/models/midi_loader.py
+++ b/models/midi_loader.py
@@ -13,8 +13,9 @@ has to import ``basic_pitch.inference`` directly.
 GPU / CPU note
 --------------
 BasicPitch runs on CPU only (the loader sets ``CUDA_VISIBLE_DEVICES=-1``
-before TF is imported via ``BasicPitchModelLoader``).  The MIDI pipeline
-is therefore purely CPU-bound; Demucs/MusicGen GPU memory is unaffected.
+before TF is imported via ``BasicPitchModelLoader``).  The ADTOF drum
+model uses the best available torch device and is evicted by the pipeline
+after drum stems are processed, so GPU memory is only held transiently.
 """
 
 import pathlib
@@ -32,11 +33,13 @@ log = logging.getLogger("stemforge.models.midi_loader")
 class MidiModelLoader:
     """Facade that converts audio files to MIDI note events.
 
-    Exposes two conversion paths:
+    Exposes three conversion paths:
 
     * :meth:`convert_audio_to_midi` — uses BasicPitch (good for instruments).
     * :meth:`convert_vocal_to_midi` — uses faster-whisper for word timing
       and librosa PYIN for pitch estimation (better for sung vocals).
+    * :meth:`convert_drum_to_midi` — uses ADTOF for percussion (BasicPitch
+      is a pitched-instrument model and garbles unpitched drums).
 
     Lifecycle mirrors all other StemForge loaders::
 
@@ -53,6 +56,7 @@ class MidiModelLoader:
     def __init__(self) -> None:
         self._bp_loader = BasicPitchModelLoader()
         self._model: Any | None = None          # BasicPitch TF model
+        self._adtof: Any | None = None          # AdtofModelLoader (lazy)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -90,10 +94,17 @@ class MidiModelLoader:
         return self._model is not None
 
     def evict(self) -> None:
-        """Release both models from memory and trigger GC."""
+        """Release all models from memory and trigger GC."""
         self._bp_loader.evict()
         self._model = None
+        self.evict_drum_model()
         log.debug("MidiModelLoader: models evicted.")
+
+    def evict_drum_model(self) -> None:
+        """Release only the ADTOF drum model, leaving BasicPitch intact."""
+        if self._adtof is not None:
+            self._adtof.evict()
+            self._adtof = None
 
     # ------------------------------------------------------------------
     # High-level conversion
@@ -347,3 +358,50 @@ class MidiModelLoader:
             path.name, len(events), len(lyrics), len(segments),
         )
         return events, lyrics
+
+    def convert_drum_to_midi(
+        self,
+        path: pathlib.Path,
+        *,
+        duration: float = 0.0,
+    ) -> list[NoteEvent]:
+        """Transcribe a drum stem to GM percussion note events via ADTOF.
+
+        The ADTOF model is lazy-loaded on first use and cached until
+        :meth:`evict` or :meth:`evict_drum_model` is called.
+
+        Parameters
+        ----------
+        path:
+            Drum audio file.  Any sample rate; resampled internally.
+        duration:
+            If positive, clip note events to ``[0, duration)`` seconds.
+
+        Returns
+        -------
+        list[NoteEvent]
+            ``(start_sec, end_sec, gm_note, velocity)`` tuples sorted by
+            start time, for a channel-10 (``is_drum``) instrument.
+
+        Raises
+        ------
+        :class:`~utils.errors.ModelLoadError`
+            If the ADTOF model cannot be loaded.
+        :class:`~utils.errors.PipelineExecutionError`
+            If drum transcription fails.
+        """
+        if self._adtof is None:
+            from models.adtof_loader import AdtofModelLoader
+            self._adtof = AdtofModelLoader()
+
+        events = self._adtof.predict(path)
+
+        if duration > 0.0:
+            events = [
+                (s, min(e, duration), p, v)
+                for s, e, p, v in events
+                if s < duration
+            ]
+
+        log.debug("convert_drum_to_midi: %s → %d drum events", path.name, len(events))
+        return events

--- a/models/registry.py
+++ b/models/registry.py
@@ -184,6 +184,20 @@ class BasicPitchSpec(ModelSpec):
 
 
 @dataclass(frozen=True, slots=True)
+class DrumMidiSpec(ModelSpec):
+    """Descriptor for an automatic drum transcription (ADT) model.
+
+    Additional fields
+    -----------------
+    class_labels:
+        Human-readable label for each drum output class, in model
+        output order.
+    """
+
+    class_labels: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class WhisperSpec(ModelSpec):
     """Descriptor for a faster-whisper vocal transcription model.
 
@@ -441,6 +455,36 @@ BASICPITCH = _register(BasicPitchSpec(
     min_note_range=(20.0, 500.0),
     default_onset=0.5,
     default_frame=0.3,
+))
+
+# ---------------------------------------------------------------------------
+# Drum transcription (ADT)
+# ---------------------------------------------------------------------------
+
+ADTOF_DRUMS = _register(DrumMidiSpec(
+    model_id="adtof-drums",
+    display_name="ADTOF Drums (5-class)",
+    version="0.1.0",
+    source="xavriley/ADTOF-pytorch",
+    device="auto",
+    gpu_capable=True,
+    device_fallback="cpu",
+    device_quirks="",
+    sample_rate=44_100,
+    hop_size=0,
+    chunk_size=0,
+    max_duration_seconds=0.0,
+    default_bpm=0.0,
+    default_key="",
+    default_time_signature="",
+    quantize_grid="none",
+    default_min_note_ms=0.0,
+    capabilities=frozenset({"transcribe", "gpu_acceleration"}),
+    cache_subdir="adtof",
+    description="Automatic drum transcription — kick, snare, tom, hi-hat, cymbal on GM channel 10.",
+    preprocessing="Mono downmix; resample to 44 100 Hz internally; log-frequency spectrogram.",
+    postprocessing="Per-class peak picking; GM percussion note mapping; 60 ms note duration.",
+    class_labels=("kick", "snare", "tom", "hi_hat", "cymbal"),
 ))
 
 # ---------------------------------------------------------------------------

--- a/pipelines/midi_pipeline.py
+++ b/pipelines/midi_pipeline.py
@@ -34,7 +34,7 @@ from typing import Any, Callable
 
 from models.midi_loader import MidiModelLoader
 from utils.midi_io import (
-    NoteEvent, LyricEvent, MidiData,
+    NoteEvent, LyricEvent, MidiData, DRUM_STEM_LABELS,
     notes_to_midi, write_midi, merge_tracks, generate_chord_progression,
 )
 from utils.errors import (
@@ -52,6 +52,9 @@ _TICKS_PER_BEAT = 480   # standard MIDI resolution
 _VOCAL_STEM_LABELS: frozenset[str] = frozenset({
     "vocals", "Singing voice",
 })
+
+# Drum/percussion stem labels are routed to ADTOF drum transcription
+# instead of BasicPitch; the canonical label set lives in utils.midi_io.
 
 
 # ---------------------------------------------------------------------------
@@ -319,6 +322,12 @@ class MidiPipeline:
                     )
                     if lyrics:
                         track_lyrics[label] = lyrics
+                elif label in DRUM_STEM_LABELS:
+                    log.info("MidiPipeline: routing '%s' to drum path.", label)
+                    notes = self._loader.convert_drum_to_midi(
+                        path,
+                        duration=cfg.duration_seconds,
+                    )
                 else:
                     notes = self._loader.convert_audio_to_midi(
                         path,
@@ -335,9 +344,16 @@ class MidiPipeline:
 
                 # Build per-stem MIDI object in memory (not written to disk yet)
                 stem_lyrics = track_lyrics.get(label)
-                stem_midi_data[label] = self._build_stem_midi(label, notes, cfg, stem_lyrics)
+                stem_midi_data[label] = self._build_stem_midi(
+                    label, notes, cfg, stem_lyrics,
+                    is_drum=(label in DRUM_STEM_LABELS),
+                )
 
                 self._report(base_pct + (1.0 / total) * 70.0)
+
+            # Free the ADTOF model's GPU memory once all drum stems are done.
+            if any(label in DRUM_STEM_LABELS for label in stems):
+                self._loader.evict_drum_model()
 
         else:
             # Text-only: generate a diatonic chord progression
@@ -418,10 +434,12 @@ class MidiPipeline:
         notes: list[NoteEvent],
         cfg: MidiConfig,
         lyrics: list[LyricEvent] | None = None,
+        is_drum: bool = False,
     ) -> Any:
         """Build and return a PrettyMIDI object for *stem_name* (no disk write)."""
         return notes_to_midi(
-            notes, ticks_per_beat=_TICKS_PER_BEAT, tempo_bpm=cfg.bpm, lyrics=lyrics
+            notes, ticks_per_beat=_TICKS_PER_BEAT, tempo_bpm=cfg.bpm,
+            lyrics=lyrics, is_drum=is_drum,
         )
 
     def write_stem_midi(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 
     # GitHub-pinned ML components (renamed distributions)
     "demucs @ git+https://github.com/facebookresearch/demucs.git@v4.0.1",
+    "adtof-pytorch @ git+https://github.com/xavriley/ADTOF-pytorch@85c192e",
     #"basic-pitch @ git+https://github.com/spotify/basic-pitch.git",    
 
     # Demucs deps

--- a/tests/test_midi_io_drum.py
+++ b/tests/test_midi_io_drum.py
@@ -1,0 +1,52 @@
+"""Tests for the is_drum parameter in utils.midi_io.notes_to_midi()."""
+from __future__ import annotations
+
+import pytest
+
+from utils.midi_io import DRUM_STEM_LABELS, notes_to_midi
+
+
+def test_drum_instrument_on_channel_10() -> None:
+    pm = notes_to_midi([(0.5, 1.5, 35, 100)], is_drum=True)
+    assert pm.instruments[0].is_drum is True
+    assert pm.instruments[0].name == "StemForge Drums"
+
+
+def test_default_behavior_unchanged() -> None:
+    for kwargs in ({}, {"is_drum": False}):
+        pm = notes_to_midi([(0.5, 1.5, 60, 100)], **kwargs)
+        inst = pm.instruments[0]
+        assert inst.is_drum is False
+        assert inst.program == 0
+        assert inst.name == "StemForge"
+        assert inst.notes[0].end == pytest.approx(1.5)
+
+
+def test_drum_note_capped_at_60ms() -> None:
+    pm = notes_to_midi([(1.0, 2.0, 35, 100)], is_drum=True)
+    assert pm.instruments[0].notes[0].end == pytest.approx(1.06)
+
+
+def test_short_drum_note_passthrough() -> None:
+    pm = notes_to_midi([(1.0, 1.03, 35, 100)], is_drum=True)
+    assert pm.instruments[0].notes[0].end == pytest.approx(1.03)
+
+
+def test_degenerate_drum_note_filtered() -> None:
+    pm = notes_to_midi([(1.0, 0.5, 35, 100)], is_drum=True)
+    assert pm.instruments[0].notes == []
+
+
+def test_is_drum_survives_file_roundtrip(tmp_path) -> None:
+    import pretty_midi
+
+    pm = notes_to_midi([(0.5, 1.5, 35, 100)], is_drum=True)
+    out = tmp_path / "drums.mid"
+    pm.write(str(out))
+    reloaded = pretty_midi.PrettyMIDI(str(out))
+    assert reloaded.instruments[0].is_drum is True
+
+
+def test_drum_stem_labels_cover_known_separators() -> None:
+    assert "drums" in DRUM_STEM_LABELS
+    assert "Drums & percussion" in DRUM_STEM_LABELS

--- a/tests/test_midi_pipeline_drum_routing.py
+++ b/tests/test_midi_pipeline_drum_routing.py
@@ -1,0 +1,78 @@
+"""Tests for drum stem routing in MidiPipeline.run()."""
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import MagicMock
+
+from pipelines.midi_pipeline import MidiConfig, MidiPipeline
+
+
+def _pipeline_with_mock_loader() -> tuple[MidiPipeline, MagicMock]:
+    """MidiPipeline wired to a mock loader, bypassing load_model()."""
+    pipeline = MidiPipeline()
+    pipeline.configure(MidiConfig())
+    loader = MagicMock()
+    loader.convert_drum_to_midi.return_value = [(0.1, 0.16, 35, 100)]
+    loader.convert_audio_to_midi.return_value = [(0.1, 0.4, 60, 80)]
+    loader.convert_vocal_to_midi.return_value = ([(0.1, 0.5, 60, 80)], [])
+    pipeline._loader = loader
+    pipeline.is_loaded = True
+    return pipeline, loader
+
+
+def _stem(tmp_path: pathlib.Path, name: str) -> pathlib.Path:
+    path = tmp_path / name
+    path.write_bytes(b"\x00")
+    return path
+
+
+def test_drums_label_routes_to_adt(tmp_path) -> None:
+    pipeline, loader = _pipeline_with_mock_loader()
+    pipeline.run({"drums": _stem(tmp_path, "drums.wav")})
+    assert loader.convert_drum_to_midi.called
+    assert not loader.convert_audio_to_midi.called
+
+
+def test_roformer_drum_label_routes_to_adt(tmp_path) -> None:
+    pipeline, loader = _pipeline_with_mock_loader()
+    pipeline.run({"Drums & percussion": _stem(tmp_path, "dp.wav")})
+    assert loader.convert_drum_to_midi.called
+    assert not loader.convert_audio_to_midi.called
+
+
+def test_bass_label_still_uses_basicpitch(tmp_path) -> None:
+    pipeline, loader = _pipeline_with_mock_loader()
+    pipeline.run({"bass": _stem(tmp_path, "bass.wav")})
+    assert loader.convert_audio_to_midi.called
+    assert not loader.convert_drum_to_midi.called
+
+
+def test_vocals_label_still_uses_vocal_path(tmp_path) -> None:
+    pipeline, loader = _pipeline_with_mock_loader()
+    pipeline.run({"vocals": _stem(tmp_path, "vocals.wav")})
+    assert loader.convert_vocal_to_midi.called
+    assert not loader.convert_drum_to_midi.called
+
+
+def test_drum_stem_midi_is_drum(tmp_path) -> None:
+    pipeline, _ = _pipeline_with_mock_loader()
+    result = pipeline.run({"drums": _stem(tmp_path, "drums.wav")})
+    assert result.stem_midi_data["drums"].instruments[0].is_drum is True
+
+
+def test_non_drum_stem_midi_not_drum(tmp_path) -> None:
+    pipeline, _ = _pipeline_with_mock_loader()
+    result = pipeline.run({"bass": _stem(tmp_path, "bass.wav")})
+    assert result.stem_midi_data["bass"].instruments[0].is_drum is False
+
+
+def test_drum_model_evicted_after_run(tmp_path) -> None:
+    pipeline, loader = _pipeline_with_mock_loader()
+    pipeline.run({"drums": _stem(tmp_path, "drums.wav")})
+    assert loader.evict_drum_model.called
+
+
+def test_drum_model_not_evicted_without_drums(tmp_path) -> None:
+    pipeline, loader = _pipeline_with_mock_loader()
+    pipeline.run({"bass": _stem(tmp_path, "bass.wav")})
+    assert not loader.evict_drum_model.called

--- a/utils/midi_io.py
+++ b/utils/midi_io.py
@@ -288,10 +288,15 @@ _STEM_GM_PROGRAM: dict[str, int] = {
     "generated":             0,   # Acoustic Grand Piano
 }
 
-_STEM_IS_DRUM: dict[str, bool] = {
-    "drums":              True,
-    "Drums & percussion": True,
-}
+# Canonical set of stem labels that represent drums/percussion.  Single
+# source of truth — the MIDI pipeline (ADT routing) and the API layer
+# (track defaults) both derive from this.
+DRUM_STEM_LABELS: frozenset[str] = frozenset({
+    "drums",                  # Demucs output label
+    "Drums & percussion",     # BS-Roformer 4/6-stem output label
+})
+
+_STEM_IS_DRUM: dict[str, bool] = {label: True for label in DRUM_STEM_LABELS}
 
 
 def merge_tracks(

--- a/utils/midi_io.py
+++ b/utils/midi_io.py
@@ -86,6 +86,7 @@ def notes_to_midi(
     ticks_per_beat: int = 480,
     tempo_bpm: float = 120.0,
     lyrics: list[LyricEvent] | None = None,
+    is_drum: bool = False,
 ) -> MidiData:
     """Convert a list of note events to a MIDI data object.
 
@@ -97,6 +98,11 @@ def notes_to_midi(
         MIDI ticks per quarter-note (resolution).
     tempo_bpm:
         Tempo in beats per minute for the generated MIDI file.
+    lyrics:
+        Optional ``(time_sec, word)`` lyric events to embed.
+    is_drum:
+        When ``True``, the instrument is routed to the General MIDI
+        percussion channel (10) and note durations are capped at 60 ms.
 
     Returns
     -------
@@ -107,14 +113,24 @@ def notes_to_midi(
         resolution=int(ticks_per_beat),
         initial_tempo=float(tempo_bpm),
     )
-    instrument = pretty_midi.Instrument(
-        program=pretty_midi.instrument_name_to_program("Acoustic Grand Piano"),
-        name="StemForge",
-    )
+    if is_drum:
+        instrument = pretty_midi.Instrument(
+            program=0,
+            is_drum=True,
+            name="StemForge Drums",
+        )
+    else:
+        instrument = pretty_midi.Instrument(
+            program=pretty_midi.instrument_name_to_program("Acoustic Grand Piano"),
+            name="StemForge",
+        )
     for start, end, pitch, velocity in note_events:
         # Guard against degenerate notes (zero or negative duration).
         if end <= start:
             continue
+        if is_drum:
+            # Percussion hits are instantaneous — long "notes" render badly.
+            end = min(end, start + 0.06)
         note = pretty_midi.Note(
             velocity=max(1, min(127, int(velocity))),
             pitch=max(0, min(127, int(pitch))),

--- a/utils/midi_io.py
+++ b/utils/midi_io.py
@@ -296,7 +296,7 @@ DRUM_STEM_LABELS: frozenset[str] = frozenset({
     "Drums & percussion",     # BS-Roformer 4/6-stem output label
 })
 
-_STEM_IS_DRUM: dict[str, bool] = {label: True for label in DRUM_STEM_LABELS}
+_STEM_IS_DRUM: dict[str, bool] = dict.fromkeys(DRUM_STEM_LABELS, True)
 
 
 def merge_tracks(

--- a/uv.lock
+++ b/uv.lock
@@ -133,6 +133,17 @@ requires-dist = [
 dev = []
 
 [[package]]
+name = "adtof-pytorch"
+version = "0.1.0"
+source = { git = "https://github.com/xavriley/ADTOF-pytorch?rev=85c192e#85c192e78f716ea0b111cc8a5ee4a8f6a3a4f8a9" }
+dependencies = [
+    { name = "librosa", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "pretty-midi", marker = "sys_platform == 'linux'" },
+    { name = "torch", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
 name = "ai-edge-litert"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2646,6 +2657,7 @@ source = { editable = "." }
 dependencies = [
     { name = "accelerate", marker = "sys_platform == 'linux'" },
     { name = "ace-step", marker = "sys_platform == 'linux'" },
+    { name = "adtof-pytorch", marker = "sys_platform == 'linux'" },
     { name = "ai-edge-litert", marker = "sys_platform == 'linux'" },
     { name = "audio-separator", marker = "sys_platform == 'linux'" },
     { name = "bs-roformer", marker = "sys_platform == 'linux'" },
@@ -2717,6 +2729,7 @@ dev = [
 requires-dist = [
     { name = "accelerate", specifier = ">=0.30.0" },
     { name = "ace-step", editable = "Ace-Step-Wrangler/vendor/ACE-Step-1.5" },
+    { name = "adtof-pytorch", git = "https://github.com/xavriley/ADTOF-pytorch?rev=85c192e" },
     { name = "ai-edge-litert", specifier = ">=1.1.0" },
     { name = "audio-separator", directory = "vendor/python-audio-separator" },
     { name = "bs-roformer", specifier = ">=0.3.2" },


### PR DESCRIPTION
## Summary

Reimplementation of #10 following project conventions. Credit to @kurtjcu for the idea and groundwork — drums were previously routed through BasicPitch (a pitched-instrument model) and produced garbled output; this routes drum stems through [ADTOF-pytorch](https://github.com/xavriley/ADTOF-pytorch) drum transcription instead (kick, snare, tom, hi-hat, cymbal → GM channel 10).

## What changed

- `models/adtof_loader.py` — new loader following the existing load/predict/evict shape; device via `utils.device.get_device()`; the library's `LABELS_5` already yields GM note numbers, so no separate mapping table
- `models/midi_loader.py` — `convert_drum_to_midi()` facade, lazy-loaded like the whisper path; `evict_drum_model()` frees ADTOF independently of BasicPitch
- `pipelines/midi_pipeline.py` — drum-label routing branch; ADTOF evicted after drum stems are processed
- `utils/midi_io.py` — `is_drum` param on `notes_to_midi()` (channel 10 + 60 ms percussion cap); `DRUM_STEM_LABELS` as the single source of drum-label truth (pipeline routing, `merge_tracks`, and the API's `STEM_IS_DRUM` all derive from it)
- `models/registry.py` — `DrumMidiSpec` + `adtof-drums` entry; listed in `/api/models`
- `frontend/components/midi.js` — one-line hint under the stem list when a drum stem is checked
- `tests/` — lean pytest coverage: `is_drum` MIDI output and pipeline routing

## Differences from #10

- Loader lives in `models/` per the layer convention; no `Protocol` abstraction, no production asserts, no `utils/drum_map.py` (redundant with the library's own label list)
- Model runs on GPU when available (`get_device()`); #10 always ran on CPU
- No hard 44.1 kHz rejection — the library resamples internally via librosa
- Dropped the `adt_model` request param and dropdown (single model; the param never reached the pipeline)
- Commits are DCO-signed; no unrelated `.gitignore`/whitespace changes

## Test plan

- [x] `pytest tests/test_midi_io_drum.py tests/test_midi_pipeline_drum_routing.py` — 15 passed
- [x] Real drum stem (220 s): 879 events, plausible class distribution (kick 221 / snare 134 / hi-hat 509 / cymbal 15), 1.5 s inference on GPU, channel-10 output in both per-stem and merged MIDI
- [x] Pitched stem still routes to BasicPitch; vocals still route to whisper+PYIN (no regression)
- [x] ruff findings identical to main baseline (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)