### PR TITLE
Web MIDI Output — play extracted MIDI stems on hardware synths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run tests
         run: >
           uv run pytest -q
+          tests/test_midi_events.py
           tests/test_midi_io_drum.py
           tests/test_midi_io_format0.py
           tests/test_midi_pipeline_drum_routing.py

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ StemForge runs entirely on your local machine with no internet connection requir
 - **Demucs** — stem separation (vocals, drums, bass, other) — 4 models including fine-tuned and MDX variants
 - **BS-Roformer** — high-quality AI stem separation with 2-stem vocal, 4-stem, and 6-stem (guitar + piano) models
 - **MIDI extraction** — polyphonic BasicPitch for instruments, faster-whisper + pitch tracking for vocals; per-stem MIDI preview via FluidSynth
+- **MIDI Out** — stream extracted MIDI straight to hardware synths via Web MIDI, with per-stem port/channel routing, optional Program Change, and a Panic button (Chrome/Edge required)
 - **Enhance** — three-mode vocal enhancement: Clean Up (8 UVR denoise/dereverb presets), Tune (CREPE + Praat PSOLA auto-tune with key/scale snapping), Effects (planned)
 - **Stable Audio Open** — text-conditioned audio generation up to 600 s, with optional audio and MIDI conditioning (Synth tab)
 - **SFX Stem Builder** — DAW-style timeline canvas for placing audio clips with per-clip fades and volume, aligned to a reference stem (Synth tab)
@@ -313,7 +314,7 @@ AI-powered stem separation using Demucs and BS-Roformer. Upload any audio or vid
 Three-mode vocal enhancement. **Clean Up** applies UVR denoise, dereverb, or debleed via 8 curated presets across Roformer/MDXC/VR architectures. **Tune** applies auto-tune via CREPE neural pitch detection + WORLD vocoder resynthesis — choose key, scale, correction strength, and humanization. **Effects** is planned (custom DSP via scipy.signal). Batch mode supported for Clean Up.
 
 ### MIDI
-Extract MIDI from separated stems. BasicPitch handles polyphonic instrument stems; faster-whisper + PYIN pitch tracking handles vocal melodies. Per-stem FluidSynth preview lets you audition MIDI renderings directly in the browser via wavesurfer.js.
+Extract MIDI from separated stems. BasicPitch handles polyphonic instrument stems; faster-whisper + PYIN pitch tracking handles vocal melodies. Per-stem FluidSynth preview lets you audition MIDI renderings directly in the browser via wavesurfer.js. **MIDI Out** streams any stem to hardware synthesizers over the Web MIDI API — per-stem port/channel routing, simultaneous playback on multiple ports, optional Program Change, and a global Panic button. Requires Chrome or Edge and a secure context (localhost or HTTPS).
 
 ### Synth
 Text-conditioned audio generation via Stable Audio Open 1.0 (44,100 Hz stereo).

--- a/backend/api/midi.py
+++ b/backend/api/midi.py
@@ -125,6 +125,10 @@ class RenderRequest(BaseModel):
     is_drum: bool = False
 
 
+class EventsRequest(BaseModel):
+    stem_label: str
+
+
 class SaveRequest(BaseModel):
     label: str = "merged"    # "merged" or a stem label
     smf_format: int = 1      # 1 = multi-track, 0 = single-track (hardware arrangers)
@@ -259,6 +263,106 @@ def render_midi_to_audio(req: RenderRequest, session: SessionStore = Depends(get
     return {
         "audio_path": str(out_path),
         "duration": len(audio) / sr,
+    }
+
+
+# Hard cap on events per /events response. A stem this dense is almost
+# certainly a BasicPitch artefact and should go through Clean Up first.
+MAX_MIDI_OUT_EVENTS = 20000
+
+
+def _flatten_instrument_notes(inst) -> list[tuple[float, float, int, int]]:
+    """Clean one instrument's notes for Web MIDI: (start, end, pitch, vel).
+
+    Drops zero-length notes, clamps pitch to 0-127 and note-on velocity to
+    1-127 (velocity 0 reads as note-off on hardware), and merges overlapping
+    same-pitch notes by truncating the earlier note to the later one's start
+    — hardware cannot represent the overlap, and the frontend's sounding-set
+    would corrupt.
+    """
+    notes = [n for n in inst.notes if n.end > n.start]
+    notes.sort(key=lambda n: (n.start, n.pitch))
+
+    cleaned: list[tuple[float, float, int, int] | None] = []
+    last_by_pitch: dict[int, int] = {}
+    for n in notes:
+        pitch = min(max(int(n.pitch), 0), 127)
+        vel = min(max(int(n.velocity), 1), 127)
+        start, end = float(n.start), float(n.end)
+        prev_i = last_by_pitch.get(pitch)
+        if prev_i is not None:
+            prev = cleaned[prev_i]
+            if prev is not None and prev[1] > start:
+                if start > prev[0]:
+                    cleaned[prev_i] = (prev[0], start, pitch, prev[3])
+                else:
+                    cleaned[prev_i] = None  # same start — earlier note vanishes
+        cleaned.append((start, end, pitch, vel))
+        last_by_pitch[pitch] = len(cleaned) - 1
+    return [c for c in cleaned if c is not None]
+
+
+@router.post("/events")
+def get_midi_events(
+    req: EventsRequest,
+    session: SessionStore = Depends(get_user_session),
+) -> dict:
+    """Flatten a session PrettyMIDI to a JSON note-event list for Web MIDI.
+
+    Returns one entry in ``tracks`` per PrettyMIDI instrument.  Events
+    within a track are sorted ascending by time, note-off before note-on
+    at equal timestamps.  Read-only — session MIDI is never modified.
+    """
+    midi_data = _resolve_midi(req.stem_label, session)
+
+    track_notes = [
+        (inst, _flatten_instrument_notes(inst)) for inst in midi_data.instruments
+    ]
+
+    # Truncate by whole notes (never split an on from its off): drop the
+    # latest-starting notes across all tracks until under the event cap.
+    truncated = False
+    total_notes = sum(len(notes) for _, notes in track_notes)
+    if total_notes * 2 > MAX_MIDI_OUT_EVENTS:
+        truncated = True
+        keep = MAX_MIDI_OUT_EVENTS // 2
+        indexed = [
+            (note[0], ti, note)
+            for ti, (_, notes) in enumerate(track_notes)
+            for note in notes
+        ]
+        indexed.sort(key=lambda x: x[0])
+        kept_per_track: list[list[tuple[float, float, int, int]]] = [
+            [] for _ in track_notes
+        ]
+        for _, ti, note in indexed[:keep]:
+            kept_per_track[ti].append(note)
+        track_notes = [
+            (inst, kept_per_track[ti]) for ti, (inst, _) in enumerate(track_notes)
+        ]
+
+    tracks = []
+    total_events = 0
+    for inst, notes in track_notes:
+        events = []
+        for start, end, pitch, vel in notes:
+            events.append({"t": start, "type": "on", "note": pitch, "vel": vel})
+            events.append({"t": end, "type": "off", "note": pitch, "vel": 0})
+        events.sort(key=lambda e: (e["t"], 0 if e["type"] == "off" else 1))
+        total_events += len(events)
+        tracks.append({
+            "name": inst.name or req.stem_label,
+            "is_drum": bool(inst.is_drum),
+            "program": int(inst.program),
+            "events": events,
+        })
+
+    return {
+        "label": req.stem_label,
+        "duration": float(midi_data.get_end_time()),
+        "total_events": total_events,
+        "truncated": truncated,
+        "tracks": tracks,
     }
 
 

--- a/docs/FUTURE_PLANS.md
+++ b/docs/FUTURE_PLANS.md
@@ -315,6 +315,26 @@ _Add future feature ideas below this line._
 - Export stems + MIDI in a format that opens directly as a DAW project
   (e.g., Reaper project file, Ableton Live Set via ALS XML)
 - Alternatively, a VST plugin wrapper for real-time stem separation
+- Hardware MIDI output is already live (MIDI tab → MIDI Out, Web MIDI) —
+  see `docs/WEB_MIDI_OUT_SPEC.md`; the items below are its deferred follow-ups
+
+### Web MIDI follow-ups (deferred from the MIDI Out feature)
+- **MIDI input** — record a hardware performance into StemForge as a new
+  MIDI track, or as an alternative to BasicPitch extraction. The Web MIDI
+  access plumbing in `frontend/components/webmidi.js` is reusable; the
+  harder part is the return leg, since StemForge has no audio capture path.
+  Needs its own spec.
+- **Transport sync** — MIDI Clock / MTC / MMC so hardware follows the
+  transport bar (meaningful only once there is a unified timeline).
+- **Pitch bend and CC** — carry `PrettyMIDI.pitch_bends` and
+  `control_changes` through `/api/midi/events`; waiting on a pipeline that
+  actually produces them. The response shape has room for `bend`/`cc`
+  event types without a breaking change.
+- **Multi-port merged playback** — route each instrument of the merged
+  MIDI to a different port/channel from a single card; the `tracks[]`
+  response shape already supports it.
+- **Seek / start-from-playhead** — a `startSec` argument to `play()` plus
+  a rule for notes already sounding at the seek point.
 
 ### Improved audio generation
 - Evaluate newer open-source generation models as they emerge

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -145,6 +145,54 @@ In Lyrics mode:
 
 Click **Send to Compose** on the result card to import the lyrics into the Compose tab's "My Lyrics" textarea (you'll be asked before any existing text is replaced).
 
+### 4.2 · MIDI Out — playing stems on hardware synths
+
+Every extracted or imported MIDI stem can be streamed directly to a hardware
+synthesizer over the browser's Web MIDI API — no drivers or extra software.
+The MIDI port lives on the **browser's** machine, so this works even when the
+StemForge server runs elsewhere.
+
+**Usage:**
+
+1. The **MIDI Out** panel in the left column shows port status. On first use
+   click **Request access** and allow the browser's MIDI permission prompt —
+   once granted, the button disappears and the panel shows the port count.
+   The port list updates automatically when you plug or unplug interfaces.
+2. Each stem card gains a **MIDI Out** row: pick a port and channel, then
+   click **Send**. The FluidSynth **Play** preview is a separate transport —
+   both can run at once, and Send never touches the waveform.
+3. Two cards can play simultaneously on different ports or channels (e.g.
+   bass → one synth, melody → another). Starting a Send on a port+channel
+   that is already playing stops the previous card first.
+4. **Send Program Change** (off by default) transmits the card's instrument
+   selection as a GM Program Change before playback. Leave it off to keep
+   whatever patch you have dialled in on the synth. Drum stems never send
+   Program Change, and the channel is always your dropdown choice — channel
+   10 is not forced for drums.
+5. **Stop** on the card silences that stem; **Panic** in the left column
+   silences every known port on all 16 channels at any time.
+6. Port and channel choices are remembered per stem label across sessions
+   (matched by port name; if the interface isn't connected, the selection
+   falls back to None).
+
+Edits made with Clean Up or Transpose while a card is playing take effect on
+the next Send — hardware keeps playing the pre-edit snapshot until then.
+
+**Browser support:** Chrome and Edge implement Web MIDI. Firefox gates it
+behind a site-permission add-on flow and is not supported; the panel will
+tell you when the browser lacks Web MIDI.
+
+**Secure context:** Web MIDI requires HTTPS or localhost. Opening StemForge
+at `http://localhost:8765` works; a plain `http://` LAN address does not.
+For LAN use, either serve StemForge behind an HTTPS reverse proxy, or (for
+single-machine testing only) add the origin to Chrome's
+`chrome://flags/#unsafely-treat-insecure-origin-as-secure` flag.
+
+**Ports missing? (Linux/ALSA port contention):** ALSA sequencer ports held
+exclusively by another application will not appear in the browser. Close any
+DAW or sequencer that has the device open, then check `aconnect -l` to
+confirm the device is visible to ALSA before looking for it in StemForge.
+
 ---
 
 ## 5. Synth — Audio Generation & SFX Stem Builder

--- a/docs/WEB_MIDI_OUT_SPEC.md
+++ b/docs/WEB_MIDI_OUT_SPEC.md
@@ -1,0 +1,705 @@
+# Web MIDI Output — Technical Specification (rev. 2)
+
+**Feature:** Play extracted MIDI stems directly to external hardware synthesizers
+**Location:** MIDI tab — per-stem card controls + a global MIDI Out panel in the left column
+**Dependencies:** None. Web MIDI API is a W3C browser API; no Python or JS packages added.
+
+> **Revision 2.** Supersedes the initial draft. Substantive changes:
+> two-phase Stop (the queued-window hole), Web Worker clock (background-tab
+> throttling), disconnect-scoped port-change handling, explicit multi-track
+> merge rules, overlap merging in the backend flattener, velocity clamp scoped
+> to note-ons, truncation-by-notes invariant, Program Change suppression keyed
+> off drum-stem status, and reuse of the existing `_resolve_midi` helper.
+> Each change is marked **[rev2]** where it matters.
+
+---
+
+## Overview
+
+StemForge currently treats MIDI as a file format and a FluidSynth preview source.
+This spec adds a third destination: the user's physical MIDI ports, so extracted
+stems can be auditioned on hardware synths (the reference setup is a Korg modwave
+and a Korg wavestate on separate MIDI ins).
+
+The MIDI port lives on the **browser's** machine, not the server's. This is the
+deciding architectural fact: a server-side `python-rtmidi` port is meaningless
+when StemForge is deployed to HF Spaces or accessed from another machine on the
+LAN. Web MIDI puts the port where the hardware actually is.
+
+The backend keeps ownership of the MIDI data — it flattens the session
+`PrettyMIDI` to a JSON event list. The frontend does no MIDI parsing, needs no
+parsing library, and only schedules and sends. Thick backend / thin frontend is
+preserved.
+
+**Scope is output only.** MIDI input (recording from hardware into StemForge) is
+explicitly out of scope and deferred — see *Deferred* at the end.
+
+---
+
+## User flow
+
+```
+Separate → MIDI → [Extract] → per-stem cards appear
+                                  │
+                                  ├─ Instrument: [Electric Bass ▼]   ← existing, FluidSynth only
+                                  ├─ [▶ Play] [■ Stop]               ← existing, FluidSynth preview
+                                  │
+                                  └─ MIDI Out: [Port ▼] [Ch 1 ▼] [▶ Send] [■ Stop]   ← NEW
+```
+
+Left column gains a **MIDI Out** section: an availability banner, a
+*Request access* button (see below), and a **Panic** button that silences every
+known port regardless of which card is playing.
+
+Typical session: Julio extracts bass and "other" from a track, sets bass →
+wavestate ch 1, other → modwave ch 1, and hits Send on each. Hardware plays;
+StemForge's own FluidSynth preview stays available and independent.
+
+Imported MIDI (`POST /api/midi/import`) lands in `stem_midi_data` and gets a
+card like any extracted stem, so it gets MIDI Out for free — no extra work, but
+the test plan exercises it once.
+
+---
+
+## Backend
+
+### New endpoint: `POST /api/midi/events`
+
+Added to `backend/api/midi.py`, alongside `/render` and `/save`. Follows the
+existing `RenderRequest` pattern.
+
+```python
+class EventsRequest(BaseModel):
+    stem_label: str
+
+
+@router.post("/events")
+def get_midi_events(
+    req: EventsRequest,
+    session: SessionStore = Depends(get_user_session),
+) -> dict:
+    """Flatten a session PrettyMIDI to a JSON note-event list for Web MIDI.
+
+    Returns one entry in ``tracks`` per PrettyMIDI instrument.  Events
+    within a track are sorted ascending by time, note-off before note-on
+    at equal timestamps.
+    """
+```
+
+**[rev2] Resolution:** use the **existing** `_resolve_midi(stem_label, session)`
+helper already defined in `backend/api/midi.py` for the music21 endpoints. It
+already implements the `merged` / stem-label convention and the 404s. Do not
+add a second copy.
+
+**Response shape:**
+
+```json
+{
+  "label": "bass",
+  "duration": 187.34,
+  "total_events": 1842,
+  "truncated": false,
+  "tracks": [
+    {
+      "name": "bass",
+      "is_drum": false,
+      "program": 33,
+      "events": [
+        {"t": 0.512, "type": "on",  "note": 45, "vel": 96},
+        {"t": 0.998, "type": "off", "note": 45, "vel": 0},
+        {"t": 1.004, "type": "on",  "note": 47, "vel": 88}
+      ]
+    }
+  ]
+}
+```
+
+`total_events` counts events across **all** tracks. `duration` is
+`PrettyMIDI.get_end_time()`.
+
+**Flattening rules (per track):**
+
+1. Skip notes where `end <= start`.
+2. **[rev2] Merge overlapping same-pitch notes.** Within one track, if a note
+   of pitch P starts before an earlier note of pitch P has ended, hardware
+   cannot represent the overlap: the first note-off would silence the second
+   note, and the frontend's sounding-set would corrupt. Resolve at the source:
+   truncate the earlier note's `end` to the later note's `start` (producing
+   abutting notes, which rule 4 already handles). This is a few lines in the
+   flattener and is covered by pytest — do not push this to the frontend.
+3. Each surviving `pretty_midi.Note` becomes an `on` event at `note.start`
+   (velocity clamped to **1–127** — velocity 0 would be interpreted as
+   note-off by the receiver, which is why the floor is 1) and an `off` event
+   at `note.end` with `vel: 0`. **[rev2]** The clamp applies to note-ons
+   only; `off` events always carry velocity 0. Pitch is clamped to 0–127 on
+   both.
+4. Sort each track's events by `t`, with `off` sorting **before** `on` at
+   identical timestamps. Abutting same-pitch notes (common after music21
+   Clean Up quantization, and produced by rule 2) would otherwise leave a
+   hanging note.
+5. `program` and `is_drum` are reported for display only. **The frontend does
+   not act on them by default** — see *Program Change* below.
+6. **[rev2] Truncation invariant: truncate by notes, never by raw events.**
+   Cap `total_events` at 20000 per response. If exceeded, drop whole notes
+   from the end (latest `start` first) until under the cap — **never emit an
+   `on` whose `off` was dropped** — set `"truncated": true`, and let the
+   frontend surface a warning. A stem this dense is almost certainly a
+   BasicPitch artefact and should be run through Clean Up first.
+
+**Threading:** synchronous. This is a pure in-memory transform over data
+already in the session — microseconds, no GPU, no job manager.
+
+**Session mutation:** none. This endpoint is strictly read-only. It does not
+touch `stem_midi_data`, unlike `/clean` and `/transpose`.
+
+**Snapshot semantics.** The response is a snapshot: if the user runs Clean Up
+or Transpose while a card is playing, the hardware keeps playing the pre-edit
+events until the next Send. This is intentional — do not add invalidation
+plumbing.
+
+### No changes to `/api/capabilities`
+
+Web MIDI availability is a property of the browser, not the server. The server
+cannot report it and must not try. Detection is entirely frontend-side.
+
+---
+
+## Frontend
+
+### New module: `frontend/components/webmidi.js`
+
+A self-contained ES module in the existing `components/` directory (the
+frontend is already ESM — `app.js` loads with `type="module"`). No CDN script
+tag, no `index.html` change.
+
+```js
+/**
+ * Web MIDI output — port discovery and lookahead event scheduling.
+ *
+ * Wraps navigator.requestMIDIAccess and provides a scheduler that streams
+ * note events to a hardware port with sub-millisecond timing accuracy.
+ *
+ * Timing model: a Worker-driven tick (100 ms) scans a lookahead window
+ * (250 ms) and hands each event to output.send() with an absolute
+ * DOMHighResTimeStamp. The browser's MIDI subsystem does the precise
+ * dispatch; the tick only needs to be roughly on time. This is the
+ * standard "two clocks" pattern.
+ */
+
+export function isSupported()        // navigator.requestMIDIAccess exists
+export async function initWebMidi()  // request access, wire statechange
+export function getOutputs()         // [{id, name, manufacturer}]
+export function getOutputById(id)
+export function onPortsChanged(cb)   // subscribe to hot-plug events
+export function createScheduler(outputId, channel)
+export function panicAll()           // silence every known output
+```
+
+**`createScheduler(outputId, channel)` returns:**
+
+```js
+{
+  play(events),   // begin streaming a flat, sorted event array from t=0
+  stop(),         // two-phase halt — see Stop below
+  isPlaying(),
+  onFinish(cb),
+  onTick(cb),     // fires with current playback seconds
+}
+```
+
+**[rev2]** `channel` is fixed at creation. Changing the card's channel (or
+port) dropdown during playback has no effect until the next Send — the UI does
+not need to react, and the spec says so to keep the implementer from inventing
+live-rebind behaviour.
+
+**[rev2]** The initial draft's `startSec` parameter is dropped. Nothing in the
+UI seeks; a start-from-playhead feature can reintroduce it alongside the rule
+for notes already sounding at the seek point.
+
+### [rev2] Track merging — who flattens `tracks[]`
+
+`/api/midi/events` returns one entry per PrettyMIDI instrument so a future
+multi-port feature can route them independently, but `play(events)` takes one
+flat array and each card has exactly one port/channel pair. The rule:
+
+- **`midi.js` merges.** Before calling `play()`, concatenate every track's
+  events into one array and **re-sort with the same comparator the backend
+  uses** (ascending `t`, `off` before `on` at equal `t`). The backend's
+  per-track ordering does not survive concatenation; the tie-break must be
+  re-established across tracks or the abutting-note guarantee is lost.
+- Per-stem BasicPitch output is single-instrument, so this is usually a no-op
+  copy; `merged` and multi-instrument imports are where it matters.
+- Whether a **merged** card appears in the MIDI Out UI at all: yes, iff
+  `session.merged_midi_data` exists — same visibility rule the Save controls
+  use. All of its instruments play on the card's single port/channel;
+  per-instrument routing is deferred (see *Deferred*).
+
+### Scheduling design
+
+This is the part that determines whether it feels tight or sloppy, so it is
+specified precisely.
+
+```
+LOOKAHEAD_MS = 250    // how far ahead of the cursor we schedule
+TICK_MS      = 100    // how often we scan
+LEAD_MS      = 120    // startup delay before t=0, absorbs first-tick jitter
+FLUSH_MS     = LOOKAHEAD_MS + 50   // [rev2] second-phase stop margin
+```
+
+**[rev2] The clock runs in a Web Worker.** Chrome throttles main-thread timers
+in hidden tabs to ≥1 s (once per minute under intensive throttling). A user
+auditioning hardware synths is *expected* to switch away from the tab — their
+hands are on the modwave — so main-thread `setInterval` is disqualified, and
+the 150 ms of slack in the original design is three orders of magnitude short.
+Worker timers are not throttled this way. Mechanics:
+
+- The worker is created from an inline `Blob` URL (`new Worker(URL.createObjectURL(...))`)
+  containing only `setInterval(() => postMessage(0), TICK_MS)` — no new file to
+  serve, no path coupling to `StaticFiles`.
+- One shared worker instance for the module; each active scheduler subscribes
+  to its message. `onmessage` runs `tick()` on the main thread, where
+  `performance.now()`, the event cursor, and `output.send()` all live. The
+  worker carries no state and no times — it is purely a metronome, so the
+  worker/main-thread `timeOrigin` difference is irrelevant.
+- Do **not** widen the lookahead on `visibilitychange` instead: a wider queued
+  window directly worsens Stop latency (see below). The worker keeps both
+  properties.
+
+On `play(events)`:
+1. Record `originMs = performance.now() + LEAD_MS`.
+2. Reset the event cursor to index 0.
+3. Subscribe to the worker tick.
+
+Each `tick()`:
+1. Compute `windowEndMs = performance.now() + LOOKAHEAD_MS`.
+2. Advance the cursor, sending every event whose absolute time
+   `originMs + e.t * 1000` falls before `windowEndMs`:
+   ```js
+   const status = (e.type === 'on' ? 0x90 : 0x80) | (channel - 1);
+   output.send([status, e.note, e.vel], absMs);
+   ```
+   **[rev2]** Wrap sends in try/catch — `send()` throws `InvalidStateError` on
+   a disconnected port; treat a throw as a disconnect (stop this scheduler,
+   surface the error on the card's status field).
+3. Track sounding pitches in a `Set` — add on `on`, remove on `off`. Because
+   this is updated at *send* time, the set covers notes that are queued in the
+   browser's MIDI subsystem but not yet audible — the two-phase Stop depends
+   on this property.
+4. If a tick arrives late (starved timer), send overdue events immediately —
+   late is recoverable, silent is not. The worker clock makes multi-second
+   starvation rare rather than routine.
+5. When the cursor passes the last event, wait out the tail, then fire
+   `onFinish` and unsubscribe.
+
+**Why windowed rather than bulk-scheduling the whole file.** Sending 10000
+timestamped messages up front works in Chrome, but cancelling them depends on
+`MIDIOutput.clear()`, whose availability is inconsistent across
+implementations. The windowed scheduler bounds the queue to ~250 ms, so Stop
+can outwait it deterministically without `clear()`. **Do not use
+`output.clear()`** — the design deliberately does not depend on it.
+
+### [rev2] Stop — two phases, because the queue cannot be recalled
+
+Silence is a correctness requirement, not a nicety. A stuck note on a
+wavestate is the worst possible first impression of this feature.
+
+Events already handed to `output.send()` with future timestamps **cannot be
+recalled** without `clear()` — that is the reason `clear()` exists. So a Stop
+that only sends immediate note-offs loses the race: up to `LOOKAHEAD_MS` of
+already-queued note-**ons** fire *after* the panic messages and hang. The
+initial draft had exactly this bug. `stop()` therefore runs everything twice:
+
+**Phase 1 — immediate (timestamp 0):**
+1. Unsubscribe from the tick; no further events are queued.
+2. Explicit `note off` for every pitch in the sounding set (which, per tick
+   step 3, includes queued-but-not-yet-sounding notes).
+3. CC 120 (All Sound Off), CC 123 (All Notes Off), CC 64 = 0 (sustain off) on
+   the scheduler's channel.
+
+**Phase 2 — timestamped at `performance.now() + FLUSH_MS`,** i.e. after every
+already-queued event has fired:
+4. The same per-pitch note-offs and the same three CCs again.
+
+Phase 1 exists so audible notes cut off instantly; phase 2 exists so queued
+note-ons that fire in between are silenced within ~300 ms. The per-pitch
+offs exist because not all hardware honours CC 123; the CCs exist because the
+sounding set can drift if a tick is missed. All of it runs; none of it is
+redundant. Perceived Stop latency for anything already sounding is still
+immediate — phase 2 only mops up the queue tail.
+
+`panicAll()` runs phases 1–2 across **all 16 channels on every known output**
+(per-pitch offs replaced by CC 120/123/64 only — panic has no sounding set),
+and is wired to:
+- The Panic button in the left column — active even when no scheduler is
+  playing.
+- `window.addEventListener('pagehide', panicAll)` **and** `beforeunload`.
+  **[rev2]** `beforeunload` alone is unreliable (bfcache, mobile, tab kill);
+  `pagehide` catches more. Both are best-effort — sends during teardown may
+  not flush on every platform, which is why the Panic button exists.
+
+**[rev2] Port changes are disconnect-scoped.** The `statechange` handler fires
+on *connect* as well as disconnect. Do **not** wire it to `panicAll()` — the
+initial draft's wiring would have silenced everything the moment a third
+device was plugged in. The rule: on `statechange`, refresh the port dropdowns;
+if a **disconnected** port has an active scheduler, `stop()` that scheduler
+(phase 1 will throw into the try/catch — that's fine, the notes died with the
+port) and surface "port disconnected" on its card. Nothing else reacts.
+
+### UI changes in `frontend/components/midi.js`
+
+**Left column — new MIDI Out section**, placed after the soundfont picker in
+`initMidi()`:
+
+```
+┌─ MIDI Out ─────────────────────────────────┐
+│ ✓ 2 output ports found                     │
+│ [Request access]            [⏻ Panic]      │
+└────────────────────────────────────────────┘
+```
+
+The banner is one of four states:
+
+| Condition | Message |
+|---|---|
+| `!isSupported()` | Web MIDI is not available in this browser. Chrome or Edge is required. |
+| Not a secure context | Web MIDI requires HTTPS or localhost. Open StemForge at `http://localhost:8765`. |
+| Access denied | MIDI access was denied. Click Request access and allow the prompt. |
+| OK, zero ports | No MIDI outputs found. Connect an interface — the list updates automatically. |
+
+Follow the existing `banner banner-error` / `banner-warn` class pattern
+already used for the OSMD load failure.
+
+**[rev2] "Request access", not "Rescan".** `MIDIAccess.outputs` is a live map
+kept current by `statechange` — there is nothing to rescan, and a rescan
+button would be a no-op. The button's real job is re-invoking
+`requestMIDIAccess()` after a denial (or before first grant). Name it for what
+it does; hide it once access is granted.
+
+**Per-card — new MIDI Out row** in `buildMidiCard()`, inserted between
+`instrumentRow` and `waveContainer`:
+
+```js
+const midiOutRow = el('div', { className: 'midi-out-row' },
+  el('label', { className: 'text-dim' }, 'MIDI Out:'),
+  portSelect,       // "None" + one option per output
+  channelSelect,    // 1–16
+  sendBtn,          // "▶ Send"
+  outStopBtn,       // "■ Stop"
+  progChangeLabel,  // checkbox "Send Program Change" — UNCHECKED by default
+  outStatus,        // "Playing 0:42 / 3:07" or error text
+);
+```
+
+The row is hidden entirely when `!isSupported()` — a dead control is worse
+than no control.
+
+**Exclusivity.** Module-level `const _outSchedulers = []`, mirroring the
+existing `midiPlayers` / `stopOtherPlayers` convention. Starting a card's Send
+stops any other scheduler *on the same port and channel* only. Two cards on
+different ports (modwave + wavestate) must be able to play simultaneously —
+that is the entire point of the feature.
+
+**Independence from FluidSynth.** The hardware scheduler and the wavesurfer
+preview are separate transports. Send does not start the waveform; Play does
+not start the hardware. Do not attempt to sync them. Expect the global
+transport bar to show FluidSynth audio while hardware plays something else —
+that is correct behaviour, not a bug.
+
+### Program Change
+
+The instrument dropdown selects a **GM program for FluidSynth**. Sending it to
+hardware would overwrite whatever patch the user has dialled in on the modwave
+— hostile default behaviour.
+
+The "Send Program Change" checkbox is **off by default**. When on, the
+scheduler emits `[0xC0 | (channel-1), program]` once at `play()` before the
+first note, using the card's current instrument selection.
+
+**[rev2] Drum suppression keys off the stem, not a dropdown value.** The
+initial draft suppressed PC when the instrument selection was "Drum Kit" — no
+such dropdown entry exists; the selector is populated from
+`/api/midi/gm-programs` (128 GM names), and drum-ness is a property of the
+stem label (`STEM_IS_DRUM` / the ADTOF routing). The rule: when the card's
+stem is a drum stem (or the track reports `is_drum`), no Program Change is
+sent even with the checkbox on — GM percussion is a channel convention, not a
+program, and neither Korg is a GM drum module.
+
+Likewise, **`is_drum` must not force channel 10.** On hardware the channel is
+entirely the user's choice via the dropdown.
+
+### Persistence
+
+Port name + channel per stem label, in `localStorage` under key
+`stemforge.midiout` (the frontend has no existing localStorage usage; this
+establishes the `stemforge.*` prefix). Restore by matching on **port name**,
+not port ID — IDs are not stable across reboots. Two identical interfaces
+produce duplicate names; first match wins, documented as a limitation.
+Silently fall back to "None" when no name matches. This is the last
+implementation step and can be dropped without affecting anything else.
+
+### CSS — `frontend/style.css`
+
+```css
+.midi-out-row { }        /* flex, gap 8px, align center — mirror .midi-instrument-row */
+.midi-out-port { }       /* min-width ~180px, truncate long port names */
+.midi-out-status { }     /* var(--text-dim), monospace time display */
+.midi-out-section { }    /* left column panel, mirror the soundfont picker block */
+.btn-panic { }           /* var(--error) border, filled on hover */
+```
+
+---
+
+## DO NOT
+
+These are deliberate exclusions. Implementing any of them silently expands
+scope or introduces a failure mode.
+
+- **Do not add `python-rtmidi`, `mido`, or any Python MIDI dependency.** The
+  port belongs to the browser. Adding a server-side path creates two divergent
+  implementations.
+- **Do not request SysEx** — `requestMIDIAccess({ sysex: false })`. SysEx
+  triggers a heavier permission prompt and opens the door to device-specific
+  messages that could alter synth state.
+- **Do not use `MIDIOutput.clear()`.** The two-phase Stop exists specifically
+  so nothing depends on it.
+- **Do not run the tick on the main thread.** Hidden-tab timer throttling
+  breaks playback by seconds, not milliseconds.
+- **Do not wire `statechange` to `panicAll()`.** It fires on connect too;
+  handle disconnects per-scheduler.
+- **Do not sync hardware playback to the FluidSynth waveform.** Separate
+  transports, deliberately.
+- **Do not send Program Change by default.**
+- **Do not force channel 10 for `is_drum` tracks.**
+- **Do not add MIDI input, clock, MTC, or MMC.** Output only, no transport
+  sync.
+- **Do not modify session MIDI data.** `/api/midi/events` is read-only.
+- **Do not duplicate `_resolve_midi`.** It already exists in
+  `backend/api/midi.py`; reuse it.
+- **Do not add Web MIDI status to `/api/capabilities`.** The server cannot
+  know.
+- **Do not touch `frontend/components/audio-player.js`.** The global transport
+  bar is for audio; hardware MIDI has its own controls in the MIDI tab.
+
+---
+
+## File inventory
+
+| File | Action | Description |
+|------|--------|-------------|
+| `frontend/components/webmidi.js` | **New** | Port discovery, worker clock, lookahead scheduler, two-phase stop/panic |
+| `backend/api/midi.py` | **Edit** | Add `POST /api/midi/events` (reuses existing `_resolve_midi`) |
+| `frontend/components/midi.js` | **Edit** | MIDI Out left-column section + per-card row + track merge |
+| `frontend/style.css` | **Edit** | `.midi-out-*` classes, `.btn-panic` |
+| `tests/test_midi_events.py` | **New** | Endpoint shape, ordering, overlap merge, clamping, truncation invariant, 404s |
+| `docs/INSTRUCTIONS.md` | **Edit** | MIDI Out subsection: usage, browser support, secure-context workarounds, ALSA port contention |
+| `README.md` | **Edit** | Feature bullet + browser requirement note |
+| `docs/FUTURE_PLANS.md` | **Edit** | Move DAW/MIDI note; add MIDI input as deferred |
+
+No `pyproject.toml` change. No `pyproject.toml.ROCM` / `.MAC` change. No
+`uv.lock` change. No `index.html` change.
+
+---
+
+## Licensing impact
+
+**None.** Web MIDI is a W3C specification implemented by the browser. No
+package is added to either dependency tree, nothing enters
+`THIRD-PARTY-NOTICES.md`, and no audit is required.
+
+Given how much of this project's dependency work has been license triage —
+parselmouth, KJ MelBandRoformer, Pedalboard, the unresolved ADTOF lineage — a
+feature with zero licensing surface is worth noting explicitly.
+
+---
+
+## Testing
+
+### Automated (pytest)
+
+`tests/test_midi_events.py` covers the backend only:
+
+1. Known `PrettyMIDI` → correct event count (`2 × note count` after merge/skip
+   rules).
+2. Events sorted ascending by `t`; `off` precedes `on` at equal timestamps.
+3. Abutting same-pitch notes produce off-then-on, not on-then-off.
+4. **[rev2]** Overlapping same-pitch notes are merged: the earlier note's off
+   lands at the later note's start; no interleaved on/on/off/off survives.
+5. Note-on velocity clamped to 1–127; `off` events carry `vel: 0` untouched;
+   pitch clamped to 0–127.
+6. Zero-length notes (`end <= start`) dropped.
+7. Multi-instrument `merged` returns one `tracks` entry per instrument.
+8. Unknown `stem_label` → 404; empty session `merged` → 404.
+9. Over-cap input sets `truncated: true`, respects the 20000 cap, **and
+   [rev2] contains no `on` without its matching `off`** — the truncation
+   invariant, tested at the boundary.
+
+Web MIDI itself cannot be exercised in pytest and should not be mocked into a
+false sense of coverage.
+
+### Manual — hardware validation protocol
+
+For Julio (modwave + wavestate, Linux). Structured the same way as the AMD
+testing protocol.
+
+**Pre-flight**
+1. Browser and version. Chrome/Edge required; confirm Firefox behaviour
+   separately rather than assuming (Firefox gates Web MIDI behind a
+   site-permission add-on flow).
+2. StemForge opened at `http://localhost:8765`, not a LAN IP — Web MIDI needs
+   a secure context.
+3. `aconnect -l` — confirm both Korgs appear as ALSA sequencer clients before
+   touching StemForge.
+4. Close any DAW or sequencer holding the ports open.
+
+**Functional**
+5. Both devices listed in the port dropdown, named recognisably.
+6. Send a bass stem to the wavestate on ch 1 → notes sound, pitches correct.
+7. Send a second stem to the modwave concurrently → both play, neither
+   interrupts the other.
+8. Stop mid-playback → audible notes cut immediately; nothing hangs after the
+   ~300 ms queue flush.
+9. Panic during playback → all ports silent.
+10. Close the browser tab mid-playback → no hanging notes (`pagehide` /
+    `beforeunload`; best-effort — note platform if it fails).
+11. Unplug an interface mid-playback → that card stops with "port
+    disconnected", the other card keeps playing, port list updates, no
+    console errors. Plug a third device in mid-playback → **nothing** stops.
+12. Program Change off → synth patch unchanged. Toggle on → patch changes.
+    On a drum stem, toggle on → patch still unchanged (suppression).
+13. **[rev2]** Switch to another application for 2+ minutes while both cards
+    play (tab hidden) → playback continues gapless. This validates the worker
+    clock and is the single most likely real-world failure mode.
+14. Import an external multi-instrument `.mid` via the Import button → its
+    card plays all instruments on the selected port/channel.
+
+**Timing**
+15. Play a quantized drum stem for 3+ minutes. Listen for gaps or jitter
+    against the FluidSynth render played separately. (Long-run *drift* is
+    impossible by construction — every timestamp derives from one `originMs`
+    — so what this test catches is starvation gaps and send jitter.)
+16. Load a dense stem (>5000 notes) and confirm no stutter at bar lines under
+    CPU load.
+
+Report format: numbered item, pass/fail, and for failures the browser console
+output plus `aconnect -l` at the time.
+
+---
+
+## Effort estimate
+
+| Component | Estimate |
+|-----------|----------|
+| `POST /api/midi/events` + flattening rules (incl. overlap merge, truncation invariant) | 2–3 h |
+| `webmidi.js` — access, port discovery, hot-plug | 2 h |
+| `webmidi.js` — worker clock, lookahead scheduler, two-phase stop/panic | 5–6 h |
+| `midi.js` — left-column section + banners | 2 h |
+| `midi.js` — per-card row, track merge, exclusivity, status | 2–3 h |
+| CSS | 1 h |
+| pytest suite | 2 h |
+| localStorage persistence | 1 h |
+| Docs | 1 h |
+| Hardware validation round-trip with Julio | 2 h |
+| **Total** | **~20–23 h** |
+
+---
+
+## Risks and mitigations
+
+**Browser coverage.** Chrome and Edge implement Web MIDI on Linux via ALSA.
+Firefox's support is gated behind a site-permission add-on flow whose current
+behaviour should be verified on real hardware rather than assumed.
+*Mitigation:* feature-detect and show a clear message naming Chrome/Edge; hide
+the controls rather than showing broken ones. Confirm Firefox empirically
+during validation and document the finding.
+
+**Secure-context requirement.** `navigator.requestMIDIAccess` is undefined on
+plain `http://` to a non-localhost host. Anyone reaching StemForge over the
+LAN — which the multi-user session work explicitly supports — loses the
+feature with no obvious explanation. *Mitigation:* detect
+`window.isSecureContext` and say so precisely, naming `localhost:8765`.
+**[rev2]** `INSTRUCTIONS.md` documents the two real workarounds for LAN use:
+serve StemForge behind an HTTPS reverse proxy, or (single-machine testing
+only) Chrome's `#unsafely-treat-insecure-origin-as-secure` flag.
+
+**Queue tail on Stop.** Events inside the lookahead window are irrevocable
+once sent. *Mitigation:* the two-phase Stop; worst-case residual sound is one
+queued note lasting ~`FLUSH_MS`, then silenced.
+
+**Timer starvation.** *Mitigation:* the worker clock removes hidden-tab
+throttling, the dominant cause; the 250 ms lookahead against a 100 ms tick
+absorbs ordinary main-thread jank; a late tick sends overdue events
+immediately rather than skipping them — late is recoverable, silent is not.
+
+**Payload size.** A dense 4-minute stem can reach ~10000 events, roughly
+500 KB of JSON. Fine over localhost, wasteful over a LAN. *Mitigation:* the
+20000-event cap plus a UI nudge toward Clean Up. Compact encoding is a later
+optimisation if it ever matters.
+
+**Port contention.** ALSA ports held exclusively by a running DAW will not
+appear. *Mitigation:* troubleshooting note in `INSTRUCTIONS.md` and step 4 of
+the pre-flight.
+
+**Dropped MIDI features.** `PrettyMIDI.pitch_bends` and `control_changes` are
+not emitted. BasicPitch produces neither, but the vocal MIDI path may produce
+pitch bends worth carrying later. *Mitigation:* documented limitation; the
+`tracks` response shape has room to add `bend` and `cc` event types without a
+breaking change.
+
+**Stale snapshot.** Clean Up / Transpose during playback leaves hardware on
+pre-edit data until the next Send. *Mitigation:* accepted and documented;
+no invalidation plumbing.
+
+---
+
+## Implementation order
+
+Each step is independently testable.
+
+1. **`POST /api/midi/events`** + pytest suite. Verify by curl against a live
+   session — correct counts, correct ordering, overlap merge, truncation
+   invariant. No frontend yet.
+2. **`webmidi.js` — access and discovery.** Wire nothing to the UI; confirm
+   from the browser console that both Korgs enumerate.
+3. **`webmidi.js` — worker clock, scheduler, two-phase stop.** Drive it from
+   the console against a hand-written event array. Confirm notes sound, Stop
+   silences (including a queued-tail test: Stop immediately after Send), and
+   playback survives a hidden tab. This is the highest-risk step; do not
+   proceed until timing feels right.
+4. **`midi.js` — left-column section.** Banners, Request access, Panic. Panic
+   must work before any card can start a note.
+5. **`midi.js` — per-card row.** Port/channel selects, track merge, Send/Stop,
+   status, exclusivity, disconnect handling.
+6. **Program Change checkbox** (with drum-stem suppression).
+7. **CSS pass.**
+8. **localStorage persistence.**
+9. **Docs** — `INSTRUCTIONS.md`, `README.md`, `FUTURE_PLANS.md`.
+10. **Hardware validation** with Julio against the protocol above.
+
+Steps 1–5 are the working feature. 6–8 are polish and can ship in a follow-up.
+
+---
+
+## Deferred
+
+**MIDI input.** Recording from hardware into StemForge — capturing a
+performance on the modwave as a new MIDI track, or as an alternative to
+BasicPitch extraction. Web MIDI supports `MIDIInput` with the same permission
+grant, so the access plumbing in `webmidi.js` is reusable. The harder part is
+the return leg: StemForge has no audio capture path at all, only file upload,
+so hardware audio still has to be recorded externally and dropped on the
+Export or Mix zone. Input is a separate spec.
+
+**Transport sync.** MIDI Clock, MTC, and MMC so the hardware follows
+StemForge's transport bar, or vice versa. Meaningful only once there is a
+unified timeline; currently each tab has its own transport.
+
+**Pitch bend and CC.** Carry `PrettyMIDI.pitch_bends` and `control_changes`
+through the event list. Waiting on a pipeline that actually produces them.
+
+**Multi-port merged playback.** Route each instrument of the `merged` MIDI to
+a different port/channel from a single card, rather than requiring per-stem
+cards. The `tracks[]` response shape already supports it; only UI and
+scheduler fan-out are missing.
+
+**Seek / start-from-playhead.** Reintroduce a `startSec` argument to `play()`
+along with a defined rule for notes already sounding at the seek point.

--- a/frontend/components/midi.js
+++ b/frontend/components/midi.js
@@ -732,8 +732,12 @@ function buildMidiOutSection() {
  * Build a per-card MIDI Out row: port/channel selects, Send/Stop, status.
  * The hardware scheduler is a separate transport from the FluidSynth
  * preview — Send never touches the waveform and vice versa, by design.
+ *
+ * getProgram: () => GM program 0-127, or null when nothing sendable is
+ * selected (Drum Kit). Omitted for the merged row, which has no
+ * instrument selector — its checkbox is not rendered.
  */
-function buildMidiOutRow(label) {
+function buildMidiOutRow(label, getProgram) {
   const portSelect = el('select', { className: 'midi-out-select midi-out-port' });
   const channelSelect = el('select', { className: 'midi-out-select' });
   for (let c = 1; c <= 16; c++) {
@@ -741,11 +745,19 @@ function buildMidiOutRow(label) {
   }
   const sendBtn = el('button', { className: 'btn btn-sm', disabled: 'true' }, '▶ Send');
   const outStopBtn = el('button', { className: 'btn btn-sm', disabled: 'true' }, '■ Stop');
+  // Off by default: the instrument dropdown selects a FluidSynth patch, and
+  // silently overwriting whatever the user dialled in on their synth would
+  // be hostile. Drum stems never send PC even when checked — GM percussion
+  // is a channel convention, not a program.
+  const progChangeBox = el('input', { type: 'checkbox', className: 'midi-out-pc' });
+  const progChangeLabel = el('label', { className: 'text-dim midi-out-pc-label' },
+    progChangeBox, 'Send Program Change');
   const outStatus = el('span', { className: 'midi-out-status text-dim' });
   const row = el('div', { className: 'midi-out-row' },
     el('label', { className: 'text-dim' }, 'MIDI Out:'),
-    portSelect, channelSelect, sendBtn, outStopBtn, outStatus,
+    portSelect, channelSelect, sendBtn, outStopBtn, progChangeLabel, outStatus,
   );
+  if (!getProgram) progChangeLabel.classList.add('hidden');
 
   // A dead control is worse than no control.
   if (!window.isSecureContext || !webMidiSupported()) {
@@ -831,6 +843,15 @@ function buildMidiOutRow(label) {
     }
     entry.sched = sched;
 
+    // Program Change: only when checked, and suppressed for drum stems —
+    // keyed off the stem label / track flags, never off a dropdown value,
+    // and never forcing channel 10 (the channel is the user's choice).
+    let program = null;
+    if (progChangeBox.checked && getProgram
+        && !isDrumStem(label) && !data.tracks.some((tr) => tr.is_drum)) {
+      program = getProgram();
+    }
+
     const duration = data.duration;
     const truncNote = data.truncated ? ' — truncated, run Clean Up' : '';
     sched.onTick((sec) => {
@@ -847,7 +868,7 @@ function buildMidiOutRow(label) {
       entry.sched = null;
       resetUi('Port disconnected');
     });
-    sched.play(events);
+    sched.play(events, { program });
     outStopBtn.removeAttribute('disabled');
     syncSendState();
   }
@@ -924,7 +945,10 @@ function buildMidiCard(label, info) {
   );
 
   // MIDI Out row — hardware output, independent of the FluidSynth preview
-  const midiOutRow = buildMidiOutRow(label);
+  const midiOutRow = buildMidiOutRow(label, () => {
+    const val = instrumentSelect.value;
+    return val === 'drum' ? null : parseInt(val, 10);
+  });
 
   // Waveform container (initially empty — populated on first render)
   const waveContainer = el('div', { className: 'stem-waveform' });

--- a/frontend/components/midi.js
+++ b/frontend/components/midi.js
@@ -6,7 +6,7 @@
 import { appState, api, pollJob, el, formatTime, saveFileAs } from '../app.js';
 import { createWaveform } from './waveform.js';
 import { transportLoad, transportStop } from './audio-player.js';
-import { isSupported as webMidiSupported, initWebMidi, getOutputs, onPortsChanged, panicAll } from './webmidi.js';
+import { isSupported as webMidiSupported, initWebMidi, getOutputs, onPortsChanged, createScheduler, panicAll } from './webmidi.js';
 
 function clearChildren(elem) {
   while (elem.firstChild) elem.removeChild(elem.firstChild);
@@ -30,6 +30,13 @@ const midiPlayers = [];
 /** Web MIDI output state — access granted, and card-row refresh hooks. */
 let midiOutReady = false;
 const midiOutRefreshers = [];  // each cb receives getOutputs() on any port change
+
+/**
+ * Active per-card hardware schedulers, mirroring the midiPlayers /
+ * stopOtherPlayers convention. Exclusivity is per port+channel only:
+ * two cards on different ports (modwave + wavestate) play simultaneously.
+ */
+const _outSchedulers = [];
 
 function stopOtherPlayers(except) {
   for (const p of midiPlayers) {
@@ -562,6 +569,9 @@ async function handleMidiImport() {
 function showMidiResults(result) {
   const container = document.getElementById('midi-results');
   midiPlayers.length = 0;
+  // Old cards are about to be superseded — silence their hardware sends.
+  for (const entry of _outSchedulers) entry.stopPlayback();
+  _outSchedulers.length = 0;
 
   appState.midiLabels = result.labels || [];
   appState.midiHasMerged = !!result.has_merged;
@@ -636,6 +646,10 @@ function showMidiResults(result) {
     mergedRow.appendChild(sheetAllBtn);
 
     container.appendChild(mergedRow);
+    // The merged MIDI gets hardware output too — same visibility rule as
+    // the Save controls. All instruments play on the row's single
+    // port/channel; per-instrument routing is deferred.
+    container.appendChild(buildMidiOutRow('merged'));
   }
 
   // Per-stem result cards with full playback
@@ -715,6 +729,142 @@ function buildMidiOutSection() {
 }
 
 /**
+ * Build a per-card MIDI Out row: port/channel selects, Send/Stop, status.
+ * The hardware scheduler is a separate transport from the FluidSynth
+ * preview — Send never touches the waveform and vice versa, by design.
+ */
+function buildMidiOutRow(label) {
+  const portSelect = el('select', { className: 'midi-out-select midi-out-port' });
+  const channelSelect = el('select', { className: 'midi-out-select' });
+  for (let c = 1; c <= 16; c++) {
+    channelSelect.appendChild(el('option', { value: String(c) }, `Ch ${c}`));
+  }
+  const sendBtn = el('button', { className: 'btn btn-sm', disabled: 'true' }, '▶ Send');
+  const outStopBtn = el('button', { className: 'btn btn-sm', disabled: 'true' }, '■ Stop');
+  const outStatus = el('span', { className: 'midi-out-status text-dim' });
+  const row = el('div', { className: 'midi-out-row' },
+    el('label', { className: 'text-dim' }, 'MIDI Out:'),
+    portSelect, channelSelect, sendBtn, outStopBtn, outStatus,
+  );
+
+  // A dead control is worse than no control.
+  if (!window.isSecureContext || !webMidiSupported()) {
+    row.classList.add('hidden');
+    return row;
+  }
+
+  let sched = null;
+
+  function syncSendState() {
+    if (midiOutReady && portSelect.value) sendBtn.removeAttribute('disabled');
+    else sendBtn.setAttribute('disabled', 'true');
+  }
+
+  function refreshPortOptions(outputs) {
+    const prev = portSelect.value;
+    clearChildren(portSelect);
+    portSelect.appendChild(el('option', { value: '' }, 'None'));
+    for (const o of outputs) {
+      portSelect.appendChild(el('option', { value: o.id, title: o.name }, o.name));
+    }
+    portSelect.value = Array.from(portSelect.options).some(op => op.value === prev) ? prev : '';
+    syncSendState();
+  }
+
+  function resetUi(msg) {
+    outStopBtn.setAttribute('disabled', 'true');
+    outStatus.textContent = msg;
+    syncSendState();
+  }
+
+  function stopPlayback(msg = '') {
+    if (sched) sched.stop();
+    sched = null;
+    entry.sched = null;
+    resetUi(msg);
+  }
+
+  const entry = { sched: null, stopPlayback };
+  _outSchedulers.push(entry);
+
+  async function startSend() {
+    const portId = portSelect.value;
+    const channel = parseInt(channelSelect.value, 10);
+    if (!portId) return;
+
+    sendBtn.setAttribute('disabled', 'true');
+    outStatus.textContent = 'Loading events…';
+    let data;
+    try {
+      data = await api('/midi/events', {
+        method: 'POST',
+        body: JSON.stringify({ stem_label: label }),
+      });
+    } catch (err) {
+      resetUi(`Failed: ${err.message}`);
+      return;
+    }
+
+    // Merge all tracks into one flat array, re-sorted with the backend's
+    // comparator (ascending t, off before on at equal t) — per-track
+    // ordering does not survive concatenation, and losing the tie-break
+    // would break the abutting-note guarantee.
+    const events = [];
+    for (const track of data.tracks) events.push(...track.events);
+    events.sort((a, b) =>
+      a.t - b.t || (a.type === b.type ? 0 : a.type === 'off' ? -1 : 1));
+
+    // Exclusivity: stop other schedulers on the same port AND channel only.
+    for (const other of _outSchedulers) {
+      if (other !== entry && other.sched && other.sched.isPlaying()
+          && other.sched.outputId === portId && other.sched.channel === channel) {
+        other.stopPlayback();
+      }
+    }
+    stopPlayback();  // our own previous run, whatever port it was on
+
+    try {
+      sched = createScheduler(portId, channel);
+    } catch (err) {
+      resetUi('Port unavailable');
+      return;
+    }
+    entry.sched = sched;
+
+    const duration = data.duration;
+    const truncNote = data.truncated ? ' — truncated, run Clean Up' : '';
+    sched.onTick((sec) => {
+      outStatus.textContent =
+        `Playing ${formatTime(Math.min(sec, duration))} / ${formatTime(duration)}${truncNote}`;
+    });
+    sched.onFinish(() => {
+      sched = null;
+      entry.sched = null;
+      resetUi('');
+    });
+    sched.onError(() => {
+      sched = null;
+      entry.sched = null;
+      resetUi('Port disconnected');
+    });
+    sched.play(events);
+    outStopBtn.removeAttribute('disabled');
+    syncSendState();
+  }
+
+  sendBtn.addEventListener('click', startSend);
+  outStopBtn.addEventListener('click', () => stopPlayback());
+  // Port/channel changes during playback take effect on the next Send —
+  // the scheduler's binding is fixed at creation, deliberately.
+  portSelect.addEventListener('change', syncSendState);
+
+  midiOutRefreshers.push(refreshPortOptions);
+  refreshPortOptions(getOutputs());
+
+  return row;
+}
+
+/**
  * Build a MIDI result card with waveform, playback controls, and instrument selector.
  * Mirrors the stem cards in the Separate tab.
  */
@@ -773,6 +923,9 @@ function buildMidiCard(label, info) {
     instrumentSelect,
   );
 
+  // MIDI Out row — hardware output, independent of the FluidSynth preview
+  const midiOutRow = buildMidiOutRow(label);
+
   // Waveform container (initially empty — populated on first render)
   const waveContainer = el('div', { className: 'stem-waveform' });
   const renderHint = el('div', { className: 'midi-render-hint text-dim' }, 'Press Play to render audio preview');
@@ -830,7 +983,7 @@ function buildMidiCard(label, info) {
   // Sheet music panel placeholder
   const sheetPanel = el('div', { className: 'sheet-music-panel hidden' });
 
-  card.append(header, instrumentRow, waveContainer, renderHint, toolsRow, sheetPanel);
+  card.append(header, instrumentRow, midiOutRow, waveContainer, renderHint, toolsRow, sheetPanel);
   container.appendChild(card);
 
   // ─── MIDI Tools event handlers ───

--- a/frontend/components/midi.js
+++ b/frontend/components/midi.js
@@ -38,6 +38,30 @@ const midiOutRefreshers = [];  // each cb receives getOutputs() on any port chan
  */
 const _outSchedulers = [];
 
+/**
+ * Port + channel per stem label, persisted across sessions. Ports are
+ * matched by NAME, not id — ids are not stable across reboots. Two
+ * identical interfaces produce duplicate names; first match wins
+ * (documented limitation). No match falls back silently to "None".
+ */
+const MIDI_OUT_LS_KEY = 'stemforge.midiout';
+
+function loadMidiOutPrefs() {
+  try {
+    return JSON.parse(localStorage.getItem(MIDI_OUT_LS_KEY)) || {};
+  } catch (err) {
+    return {};
+  }
+}
+
+function saveMidiOutPref(label, portName, channel) {
+  try {
+    const prefs = loadMidiOutPrefs();
+    prefs[label] = { port: portName, channel };
+    localStorage.setItem(MIDI_OUT_LS_KEY, JSON.stringify(prefs));
+  } catch (err) { /* storage unavailable — persistence is best-effort */ }
+}
+
 function stopOtherPlayers(except) {
   for (const p of midiPlayers) {
     if (p.ws !== except && p.ws.isPlaying()) {
@@ -767,6 +791,15 @@ function buildMidiOutRow(label, getProgram) {
 
   let sched = null;
 
+  // Saved preference for this stem — the channel applies immediately, the
+  // port by name-match once ports are known. Auto-restore stops as soon as
+  // the user touches the port dropdown, so an explicit "None" sticks.
+  const pref = loadMidiOutPrefs()[label] || null;
+  let autoRestorePort = !!(pref && pref.port);
+  if (pref && pref.channel >= 1 && pref.channel <= 16) {
+    channelSelect.value = String(pref.channel);
+  }
+
   function syncSendState() {
     if (midiOutReady && portSelect.value) sendBtn.removeAttribute('disabled');
     else sendBtn.setAttribute('disabled', 'true');
@@ -779,8 +812,22 @@ function buildMidiOutRow(label, getProgram) {
     for (const o of outputs) {
       portSelect.appendChild(el('option', { value: o.id, title: o.name }, o.name));
     }
-    portSelect.value = Array.from(portSelect.options).some(op => op.value === prev) ? prev : '';
+    if (Array.from(portSelect.options).some(op => op.value === prev && prev !== '')) {
+      portSelect.value = prev;
+    } else if (autoRestorePort) {
+      const match = outputs.find(o => o.name === pref.port);  // first match wins
+      portSelect.value = match ? match.id : '';
+    } else {
+      portSelect.value = '';
+    }
     syncSendState();
+  }
+
+  function savePref() {
+    const selected = portSelect.selectedOptions[0];
+    saveMidiOutPref(label,
+      portSelect.value ? selected.textContent : null,
+      parseInt(channelSelect.value, 10));
   }
 
   function resetUi(msg) {
@@ -877,7 +924,12 @@ function buildMidiOutRow(label, getProgram) {
   outStopBtn.addEventListener('click', () => stopPlayback());
   // Port/channel changes during playback take effect on the next Send —
   // the scheduler's binding is fixed at creation, deliberately.
-  portSelect.addEventListener('change', syncSendState);
+  portSelect.addEventListener('change', () => {
+    autoRestorePort = false;
+    savePref();
+    syncSendState();
+  });
+  channelSelect.addEventListener('change', savePref);
 
   midiOutRefreshers.push(refreshPortOptions);
   refreshPortOptions(getOutputs());

--- a/frontend/components/midi.js
+++ b/frontend/components/midi.js
@@ -6,6 +6,7 @@
 import { appState, api, pollJob, el, formatTime, saveFileAs } from '../app.js';
 import { createWaveform } from './waveform.js';
 import { transportLoad, transportStop } from './audio-player.js';
+import { isSupported as webMidiSupported, initWebMidi, getOutputs, onPortsChanged, panicAll } from './webmidi.js';
 
 function clearChildren(elem) {
   while (elem.firstChild) elem.removeChild(elem.firstChild);
@@ -25,6 +26,10 @@ let _lilypondAvailable = false;
 
 /** All active MIDI card players — for exclusive playback. */
 const midiPlayers = [];
+
+/** Web MIDI output state — access granted, and card-row refresh hooks. */
+let midiOutReady = false;
+const midiOutRefreshers = [];  // each cb receives getOutputs() on any port change
 
 function stopOtherPlayers(except) {
   for (const p of midiPlayers) {
@@ -115,6 +120,9 @@ export function initMidi() {
     ),
   );
 
+  // ─── MIDI Out (Web MIDI hardware output) ───
+  const midiOutSection = buildMidiOutSection();
+
   const extractBtn = el('button', { className: 'btn btn-primary', id: 'midi-start', disabled: 'true' },
     'Extract MIDI',
   );
@@ -123,7 +131,7 @@ export function initMidi() {
   const importInput = el('input', { type: 'file', accept: '.mid,.midi', style: { display: 'none' }, id: 'midi-import-input' });
   const importBtn = el('button', { className: 'btn btn-sm', id: 'midi-import' }, 'Import MIDI file');
 
-  notesControls.append(stemSection, keyGroup, bpmGroup, tsGroup, onsetGroup, frameGroup, sf2Group, extractBtn, importInput, importBtn);
+  notesControls.append(stemSection, keyGroup, bpmGroup, tsGroup, onsetGroup, frameGroup, sf2Group, midiOutSection, extractBtn, importInput, importBtn);
   left.append(notesControls, lyricsControls);
 
   // ─── Lyrics control panel ───
@@ -634,6 +642,76 @@ function showMidiResults(result) {
   for (const [label, info] of Object.entries(result.stem_info || {})) {
     buildMidiCard(label, info);
   }
+}
+
+/**
+ * Build the left-column MIDI Out section: availability banner, Request
+ * access button, Panic button. Web MIDI availability is a browser
+ * property — detection is entirely client-side, the server cannot know.
+ */
+function buildMidiOutSection() {
+  const banner = el('div', { className: 'banner banner-info', id: 'midi-out-banner' });
+  const requestBtn = el('button', { className: 'btn btn-sm', id: 'midi-out-request' }, 'Request access');
+  const panicBtn = el('button', {
+    className: 'btn btn-sm btn-panic', id: 'midi-out-panic', disabled: 'true',
+    title: 'Silence every known MIDI output on all channels',
+  }, '⏻ Panic');
+  const actions = el('div', { className: 'midi-out-actions' }, requestBtn, panicBtn);
+  const section = el('div', { className: 'form-group midi-out-section' },
+    el('label', {}, 'MIDI Out'), banner, actions,
+  );
+
+  function setBanner(cls, text) {
+    banner.className = `banner ${cls}`;
+    banner.textContent = text;
+  }
+
+  function refreshPorts() {
+    const outputs = getOutputs();
+    if (outputs.length === 0) {
+      setBanner('banner-warn', 'No MIDI outputs found. Connect an interface — the list updates automatically.');
+    } else {
+      setBanner('banner-success', `✓ ${outputs.length} output port${outputs.length === 1 ? '' : 's'} found`);
+    }
+    for (const cb of midiOutRefreshers) {
+      try { cb(outputs); } catch (err) { console.error('MIDI Out refresh failed', err); }
+    }
+  }
+
+  async function grantAccess() {
+    try {
+      await initWebMidi();
+    } catch (err) {
+      setBanner('banner-error', 'MIDI access was denied. Click Request access and allow the prompt.');
+      return;
+    }
+    midiOutReady = true;
+    // MIDIAccess.outputs is a live map kept current by statechange —
+    // once granted there is nothing to rescan, so the button goes away.
+    requestBtn.classList.add('hidden');
+    panicBtn.removeAttribute('disabled');
+    onPortsChanged(refreshPorts);
+    refreshPorts();
+  }
+
+  if (!window.isSecureContext) {
+    setBanner('banner-error', 'Web MIDI requires HTTPS or localhost. Open StemForge at http://localhost:8765.');
+    actions.classList.add('hidden');
+  } else if (!webMidiSupported()) {
+    setBanner('banner-error', 'Web MIDI is not available in this browser. Chrome or Edge is required.');
+    actions.classList.add('hidden');
+  } else {
+    setBanner('banner-info', 'Click Request access to enable hardware MIDI output.');
+    requestBtn.addEventListener('click', grantAccess);
+    panicBtn.addEventListener('click', panicAll);
+    // If permission was already granted, initialize silently — query first
+    // so first-time visitors are not hit with a prompt on tab load.
+    navigator.permissions?.query({ name: 'midi', sysex: false })
+      .then((status) => { if (status.state === 'granted') grantAccess(); })
+      .catch(() => {});
+  }
+
+  return section;
 }
 
 /**

--- a/frontend/components/webmidi.js
+++ b/frontend/components/webmidi.js
@@ -1,0 +1,254 @@
+/**
+ * Web MIDI output — port discovery and lookahead event scheduling.
+ *
+ * Wraps navigator.requestMIDIAccess and provides a scheduler that streams
+ * note events to a hardware port with sub-millisecond timing accuracy.
+ *
+ * Timing model: a Worker-driven tick (100 ms) scans a lookahead window
+ * (250 ms) and hands each event to output.send() with an absolute
+ * DOMHighResTimeStamp. The browser's MIDI subsystem does the precise
+ * dispatch; the tick only needs to be roughly on time ("two clocks").
+ * The tick runs in a Web Worker because main-thread timers are throttled
+ * to >= 1 s in hidden tabs — and auditioning hardware synths with the tab
+ * hidden is the expected use, not the edge case.
+ *
+ * Stop runs in two phases: events already handed to output.send() with
+ * future timestamps cannot be recalled (MIDIOutput.clear() is not relied
+ * on — inconsistent support), so note-offs and panic CCs are sent once
+ * immediately and once timestamped after the lookahead queue has drained.
+ */
+
+const LOOKAHEAD_MS = 250;  // how far ahead of the cursor events are queued
+const TICK_MS = 100;       // worker metronome period
+const LEAD_MS = 120;       // startup delay before t=0, absorbs first-tick jitter
+const FLUSH_MS = LOOKAHEAD_MS + 50;  // second-phase stop margin
+
+let midiAccess = null;
+const portListeners = [];
+const activeSchedulers = new Set();
+
+// ─── Access & discovery ──────────────────────────────────────────────────
+
+export function isSupported() {
+  return typeof navigator !== 'undefined' && !!navigator.requestMIDIAccess;
+}
+
+/**
+ * Request MIDI access (sysex: false — deliberately) and wire statechange.
+ * Idempotent; rejects if unsupported or the user denies the prompt.
+ */
+export async function initWebMidi() {
+  if (!isSupported()) throw new Error('Web MIDI is not supported in this browser');
+  if (midiAccess) return midiAccess;
+  midiAccess = await navigator.requestMIDIAccess({ sysex: false });
+  midiAccess.onstatechange = (e) => {
+    // A scheduler whose port vanished is stopped here, centrally — the
+    // notes died with the port; sends would only throw. Connects are
+    // ignored beyond notifying listeners (never panic on hot-plug).
+    if (e.port && e.port.type === 'output' && e.port.state === 'disconnected') {
+      for (const s of [...activeSchedulers]) {
+        if (s.outputId === e.port.id) s.handleDisconnect();
+      }
+    }
+    for (const cb of portListeners) {
+      try { cb(e.port); } catch (err) { console.error('onPortsChanged handler failed', err); }
+    }
+  };
+  return midiAccess;
+}
+
+/** @returns {{id: string, name: string, manufacturer: string}[]} */
+export function getOutputs() {
+  if (!midiAccess) return [];
+  return [...midiAccess.outputs.values()].map((o) => ({
+    id: o.id,
+    name: o.name || o.id,
+    manufacturer: o.manufacturer || '',
+  }));
+}
+
+export function getOutputById(id) {
+  return midiAccess ? midiAccess.outputs.get(id) || null : null;
+}
+
+/** Subscribe to hot-plug events. cb receives the MIDIPort that changed. */
+export function onPortsChanged(cb) {
+  portListeners.push(cb);
+}
+
+// ─── Worker clock ────────────────────────────────────────────────────────
+// The worker carries no state and no times — it is purely a metronome, so
+// the worker/main-thread timeOrigin difference is irrelevant.
+
+let clockWorker = null;
+const tickSubscribers = new Set();
+
+function ensureClock() {
+  if (clockWorker) return;
+  const src = `setInterval(() => postMessage(0), ${TICK_MS});`;
+  clockWorker = new Worker(URL.createObjectURL(new Blob([src], { type: 'application/javascript' })));
+  clockWorker.onmessage = () => {
+    for (const fn of [...tickSubscribers]) fn();
+  };
+}
+
+// ─── Panic plumbing ──────────────────────────────────────────────────────
+
+function sendPanicCCs(output, ch, ts) {
+  output.send([0xB0 | ch, 120, 0], ts);  // All Sound Off
+  output.send([0xB0 | ch, 123, 0], ts);  // All Notes Off
+  output.send([0xB0 | ch, 64, 0], ts);   // Sustain off
+}
+
+function sendNoteOffs(output, ch, pitches, ts) {
+  for (const note of pitches) output.send([0x80 | ch, note, 0], ts);
+}
+
+/**
+ * Silence every known output on all 16 channels, immediately and again
+ * after the lookahead queue drains. Safe to call at any time.
+ */
+export function panicAll() {
+  for (const s of [...activeSchedulers]) s.stop();
+  if (!midiAccess) return;
+  const flushAt = performance.now() + FLUSH_MS;
+  for (const output of midiAccess.outputs.values()) {
+    for (let ch = 0; ch < 16; ch++) {
+      try {
+        sendPanicCCs(output, ch, 0);
+        sendPanicCCs(output, ch, flushAt);
+      } catch (err) { /* port gone — nothing left to silence */ }
+    }
+  }
+}
+
+if (typeof window !== 'undefined') {
+  // Best-effort teardown silence; pagehide catches cases beforeunload
+  // misses (bfcache, mobile). The Panic button is the reliable path.
+  window.addEventListener('pagehide', panicAll);
+  window.addEventListener('beforeunload', panicAll);
+}
+
+// ─── Scheduler ───────────────────────────────────────────────────────────
+
+/**
+ * Create a scheduler bound to one output port and one channel (1-16).
+ * Port and channel are fixed for the scheduler's lifetime — changing a
+ * dropdown mid-playback takes effect on the next Send, by design.
+ */
+export function createScheduler(outputId, channel) {
+  const output = getOutputById(outputId);
+  if (!output) throw new Error('MIDI output not found');
+  const ch = (channel - 1) & 0x0f;
+
+  let events = [];
+  let cursor = 0;
+  let originMs = 0;
+  let playing = false;
+  const sounding = new Set();  // updated at *send* time → covers queued notes
+  let finishCb = null;
+  let tickCb = null;
+  let errorCb = null;
+
+  function cleanup() {
+    playing = false;
+    tickSubscribers.delete(tick);
+    activeSchedulers.delete(scheduler);
+  }
+
+  function tick() {
+    if (!playing) return;
+    const now = performance.now();
+    const windowEnd = now + LOOKAHEAD_MS;
+    try {
+      while (cursor < events.length) {
+        const e = events[cursor];
+        const absMs = originMs + e.t * 1000;
+        if (absMs >= windowEnd) break;
+        const status = (e.type === 'on' ? 0x90 : 0x80) | ch;
+        // A starved tick sends overdue events immediately rather than
+        // skipping them — late is recoverable, silent is not.
+        output.send([status, e.note, e.vel], Math.max(absMs, now));
+        if (e.type === 'on') sounding.add(e.note);
+        else sounding.delete(e.note);
+        cursor++;
+      }
+    } catch (err) {
+      // send() throws InvalidStateError on a disconnected port.
+      scheduler.handleDisconnect(err);
+      return;
+    }
+    if (tickCb) tickCb(Math.max(0, (now - originMs) / 1000));
+    if (cursor >= events.length) {
+      const lastT = events.length ? events[events.length - 1].t : 0;
+      if (now >= originMs + lastT * 1000) {
+        cleanup();
+        sounding.clear();
+        if (finishCb) finishCb();
+      }
+    }
+  }
+
+  const scheduler = {
+    outputId,
+    channel,
+
+    /**
+     * Begin streaming a flat event array ({t, type, note, vel}, sorted
+     * ascending, off-before-on at equal t) from t=0.
+     * opts.program: GM program 0-127 to send once before the first note
+     * (the Program Change checkbox) — omit/null to leave the patch alone.
+     */
+    play(evts, opts = {}) {
+      if (playing) scheduler.stop();
+      events = evts;
+      cursor = 0;
+      sounding.clear();
+      ensureClock();
+      if (opts.program != null) {
+        output.send([0xC0 | ch, opts.program & 0x7f]);
+      }
+      originMs = performance.now() + LEAD_MS;
+      playing = true;
+      tickSubscribers.add(tick);
+      activeSchedulers.add(scheduler);
+      tick();  // prime the first window now, not TICK_MS from now
+    },
+
+    /**
+     * Two-phase halt. Phase 1 (immediate): note-off every sounding pitch,
+     * then CC 120/123/64. Phase 2 (after FLUSH_MS): the same again, so
+     * note-ons already queued in the browser's MIDI subsystem — which
+     * cannot be recalled — are silenced within ~300 ms.
+     */
+    stop() {
+      if (!playing && sounding.size === 0) return;
+      cleanup();
+      const flushAt = performance.now() + FLUSH_MS;
+      try {
+        sendNoteOffs(output, ch, sounding, 0);
+        sendPanicCCs(output, ch, 0);
+        sendNoteOffs(output, ch, sounding, flushAt);
+        sendPanicCCs(output, ch, flushAt);
+      } catch (err) { /* port gone — notes died with it */ }
+      sounding.clear();
+    },
+
+    /** Called centrally when this scheduler's port disconnects. */
+    handleDisconnect(err) {
+      cleanup();
+      sounding.clear();
+      if (errorCb) errorCb(err || new Error('MIDI port disconnected'));
+    },
+
+    isPlaying() {
+      return playing;
+    },
+
+    onFinish(cb) { finishCb = cb; },
+    onTick(cb) { tickCb = cb; },
+    onError(cb) { errorCb = cb; },
+  };
+
+  return scheduler;
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -594,6 +594,40 @@ input[type="range"]::-moz-range-track {
   gap: 8px;
 }
 
+.midi-out-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 2px;
+}
+
+.midi-out-row label {
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.midi-out-select {
+  font-size: 12px;
+  padding: 3px 6px;
+  background: var(--surface-raised);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.midi-out-port {
+  min-width: 180px;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.midi-out-status {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
 .btn-panic {
   border-color: var(--error);
   color: var(--error);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -581,6 +581,29 @@ input[type="range"]::-moz-range-track {
   gap: 6px;
 }
 
+/* ─── MIDI Out (Web MIDI hardware output) ────────────────────────────── */
+
+.midi-out-section .banner {
+  margin-bottom: 8px;
+  font-size: 12px;
+}
+
+.midi-out-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn-panic {
+  border-color: var(--error);
+  color: var(--error);
+}
+
+.btn-panic:hover:not(:disabled) {
+  background: var(--error);
+  color: #ffffff;
+}
+
 .sf2-row input[type="text"] {
   flex: 1;
   min-width: 0;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -583,6 +583,12 @@ input[type="range"]::-moz-range-track {
 
 /* ─── MIDI Out (Web MIDI hardware output) ────────────────────────────── */
 
+.midi-out-section {
+  /* #midi-controls-notes is plain block flow — without this the Panic
+     button sits flush against the Extract MIDI button below. */
+  margin-bottom: 16px;
+}
+
 .midi-out-section .banner {
   margin-bottom: 8px;
   font-size: 12px;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -596,6 +596,7 @@ input[type="range"]::-moz-range-track {
 
 .midi-out-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   padding: 0 2px;
@@ -606,7 +607,14 @@ input[type="range"]::-moz-range-track {
   white-space: nowrap;
 }
 
+.midi-out-row .btn {
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
 .midi-out-select {
+  width: auto;   /* the global select rule is 100% — these stay compact */
+  flex: 0 0 auto;
   font-size: 12px;
   padding: 3px 6px;
   background: var(--surface-raised);
@@ -616,7 +624,8 @@ input[type="range"]::-moz-range-track {
 }
 
 .midi-out-port {
-  min-width: 180px;
+  flex: 0 1 auto;
+  min-width: 140px;
   max-width: 240px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -628,6 +628,15 @@ input[type="range"]::-moz-range-track {
   white-space: nowrap;
 }
 
+.midi-out-pc-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
 .btn-panic {
   border-color: var(--error);
   color: var(--error);

--- a/tests/test_midi_events.py
+++ b/tests/test_midi_events.py
@@ -1,0 +1,295 @@
+"""Tests for POST /api/midi/events — Web MIDI event flattening.
+
+Covers the flattening rules from docs/WEB_MIDI_OUT_SPEC.md:
+event counts, ordering, overlap merging, clamping, zero-length drops,
+multi-track shape, 404s, and the truncation-by-notes invariant.
+"""
+
+from __future__ import annotations
+
+import pretty_midi
+import pytest
+from fastapi import HTTPException
+
+from backend.api.midi import EventsRequest, get_midi_events, MAX_MIDI_OUT_EVENTS
+from backend.services.session_store import SessionStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_midi(notes, program=33, is_drum=False, name="bass"):
+    """Build a single-instrument PrettyMIDI from (start, end, pitch, vel) tuples."""
+    pm = pretty_midi.PrettyMIDI()
+    inst = pretty_midi.Instrument(program=program, is_drum=is_drum, name=name)
+    for start, end, pitch, vel in notes:
+        inst.notes.append(
+            pretty_midi.Note(velocity=vel, pitch=pitch, start=start, end=end)
+        )
+    pm.instruments.append(inst)
+    return pm
+
+
+def session_with(stem_midi=None, merged=None):
+    session = SessionStore(user="test")
+    if stem_midi:
+        session.stem_midi_data = stem_midi
+    if merged is not None:
+        session.merged_midi_data = merged
+    return session
+
+
+def events_of(result, track=0):
+    return result["tracks"][track]["events"]
+
+
+def call(session, label):
+    return get_midi_events(EventsRequest(stem_label=label), session)
+
+
+# ---------------------------------------------------------------------------
+# Shape and counts
+# ---------------------------------------------------------------------------
+
+class TestShape:
+    def test_two_events_per_note(self):
+        pm = make_midi([(0.0, 0.5, 45, 96), (1.0, 1.5, 47, 88), (2.0, 2.5, 50, 70)])
+        result = call(session_with({"bass": pm}), "bass")
+        assert result["total_events"] == 6
+        assert len(events_of(result)) == 6
+        assert result["truncated"] is False
+        assert result["label"] == "bass"
+        assert result["duration"] == pytest.approx(2.5)
+
+    def test_track_metadata(self):
+        pm = make_midi([(0.0, 1.0, 60, 80)], program=33, name="bass")
+        result = call(session_with({"bass": pm}), "bass")
+        track = result["tracks"][0]
+        assert track["name"] == "bass"
+        assert track["program"] == 33
+        assert track["is_drum"] is False
+
+    def test_unnamed_instrument_falls_back_to_label(self):
+        pm = make_midi([(0.0, 1.0, 60, 80)], name="")
+        result = call(session_with({"other": pm}), "other")
+        assert result["tracks"][0]["name"] == "other"
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+class TestOrdering:
+    def test_sorted_ascending_by_time(self):
+        # Insert out of order; flattener must sort.
+        pm = make_midi([(2.0, 2.5, 50, 70), (0.0, 0.5, 45, 96), (1.0, 1.5, 47, 88)])
+        result = call(session_with({"bass": pm}), "bass")
+        times = [e["t"] for e in events_of(result)]
+        assert times == sorted(times)
+
+    def test_off_before_on_at_equal_timestamps(self):
+        # Two different pitches: one ends exactly where the other starts.
+        pm = make_midi([(0.0, 1.0, 45, 96), (1.0, 2.0, 47, 88)])
+        result = call(session_with({"bass": pm}), "bass")
+        at_one = [e for e in events_of(result) if e["t"] == 1.0]
+        assert [e["type"] for e in at_one] == ["off", "on"]
+
+    def test_abutting_same_pitch_off_then_on(self):
+        # Common after music21 Clean Up quantization: same pitch, end == start.
+        pm = make_midi([(0.0, 1.0, 45, 96), (1.0, 2.0, 45, 88)])
+        result = call(session_with({"bass": pm}), "bass")
+        at_one = [e for e in events_of(result) if e["t"] == 1.0]
+        assert [e["type"] for e in at_one] == ["off", "on"]
+        assert all(e["note"] == 45 for e in at_one)
+
+
+# ---------------------------------------------------------------------------
+# Overlap merging
+# ---------------------------------------------------------------------------
+
+class TestOverlapMerge:
+    def test_overlapping_same_pitch_truncates_earlier(self):
+        # Second note of pitch 45 starts before the first ends: the first
+        # note's off must land at the second note's start (abutting), never
+        # interleaved on/on/off/off.
+        pm = make_midi([(0.0, 1.5, 45, 96), (1.0, 2.0, 45, 88)])
+        result = call(session_with({"bass": pm}), "bass")
+        evs = events_of(result)
+        assert len(evs) == 4
+        assert [(e["t"], e["type"]) for e in evs] == [
+            (0.0, "on"), (1.0, "off"), (1.0, "on"), (2.0, "off"),
+        ]
+
+    def test_identical_start_same_pitch_drops_earlier(self):
+        # Same pitch, same start: the earlier (fully shadowed) note vanishes.
+        pm = make_midi([(1.0, 1.5, 45, 96), (1.0, 2.0, 45, 88)])
+        result = call(session_with({"bass": pm}), "bass")
+        evs = events_of(result)
+        assert len(evs) == 2
+        assert [(e["t"], e["type"]) for e in evs] == [(1.0, "on"), (2.0, "off")]
+
+    def test_overlapping_different_pitches_untouched(self):
+        pm = make_midi([(0.0, 2.0, 45, 96), (1.0, 3.0, 47, 88)])
+        result = call(session_with({"bass": pm}), "bass")
+        assert len(events_of(result)) == 4
+        offs = [e for e in events_of(result) if e["type"] == "off"]
+        assert {e["t"] for e in offs} == {2.0, 3.0}
+
+    def test_no_on_on_off_off_sequence_per_pitch(self):
+        # Sounding-set safety: per pitch, ons and offs must strictly alternate.
+        pm = make_midi([
+            (0.0, 1.5, 45, 96), (1.0, 2.5, 45, 88), (2.0, 3.0, 45, 70),
+        ])
+        result = call(session_with({"bass": pm}), "bass")
+        depth = 0
+        for e in events_of(result):
+            depth += 1 if e["type"] == "on" else -1
+            assert depth in (0, 1)
+        assert depth == 0
+
+
+# ---------------------------------------------------------------------------
+# Clamping and drops
+# ---------------------------------------------------------------------------
+
+class TestClamping:
+    def test_note_on_velocity_clamped_to_floor_1(self):
+        # Velocity 0 on a note-on would read as note-off on hardware.
+        pm = make_midi([(0.0, 1.0, 60, 0)])
+        result = call(session_with({"bass": pm}), "bass")
+        on = [e for e in events_of(result) if e["type"] == "on"][0]
+        assert on["vel"] == 1
+
+    def test_off_events_carry_velocity_zero(self):
+        pm = make_midi([(0.0, 1.0, 60, 100)])
+        result = call(session_with({"bass": pm}), "bass")
+        off = [e for e in events_of(result) if e["type"] == "off"][0]
+        assert off["vel"] == 0
+
+    def test_velocity_ceiling_127(self):
+        pm = make_midi([(0.0, 1.0, 60, 200)])
+        result = call(session_with({"bass": pm}), "bass")
+        on = [e for e in events_of(result) if e["type"] == "on"][0]
+        assert on["vel"] == 127
+
+    def test_pitch_clamped_0_127(self):
+        pm = make_midi([(0.0, 1.0, 200, 90), (2.0, 3.0, -5, 90)])
+        result = call(session_with({"bass": pm}), "bass")
+        pitches = {e["note"] for e in events_of(result)}
+        assert pitches == {127, 0}
+
+    def test_zero_length_notes_dropped(self):
+        # pretty_midi validates end > start at construction, but session MIDI
+        # can degrade to zero/negative length via mutation (e.g. quantization)
+        # — build valid notes, then corrupt them the way the wild does.
+        pm = make_midi([(0.0, 0.5, 60, 90), (1.0, 1.5, 62, 90), (2.0, 3.0, 64, 90)])
+        pm.instruments[0].notes[0].end = 0.0    # zero-length
+        pm.instruments[0].notes[1].end = 0.5    # negative-length
+        result = call(session_with({"bass": pm}), "bass")
+        assert result["total_events"] == 2
+        assert {e["note"] for e in events_of(result)} == {64}
+
+
+# ---------------------------------------------------------------------------
+# Multi-track / merged
+# ---------------------------------------------------------------------------
+
+class TestMerged:
+    def test_merged_returns_one_track_per_instrument(self):
+        pm = pretty_midi.PrettyMIDI()
+        for program, name in [(33, "bass"), (0, "piano")]:
+            inst = pretty_midi.Instrument(program=program, name=name)
+            inst.notes.append(
+                pretty_midi.Note(velocity=90, pitch=60, start=0.0, end=1.0)
+            )
+            pm.instruments.append(inst)
+        result = call(session_with(merged=pm), "merged")
+        assert len(result["tracks"]) == 2
+        assert [t["name"] for t in result["tracks"]] == ["bass", "piano"]
+        assert result["total_events"] == 4
+
+    def test_drum_instrument_reported(self):
+        pm = make_midi([(0.0, 0.2, 36, 110)], is_drum=True, name="drums")
+        result = call(session_with({"drums": pm}), "drums")
+        assert result["tracks"][0]["is_drum"] is True
+
+
+# ---------------------------------------------------------------------------
+# 404s
+# ---------------------------------------------------------------------------
+
+class TestNotFound:
+    def test_unknown_stem_404(self):
+        with pytest.raises(HTTPException) as exc:
+            call(session_with({"bass": make_midi([(0.0, 1.0, 60, 90)])}), "vocals")
+        assert exc.value.status_code == 404
+
+    def test_empty_merged_404(self):
+        with pytest.raises(HTTPException) as exc:
+            call(session_with(), "merged")
+        assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Truncation
+# ---------------------------------------------------------------------------
+
+class TestTruncation:
+    def _dense_midi(self, note_count):
+        # Non-overlapping notes, strictly increasing start times.
+        return make_midi([
+            (i * 0.1, i * 0.1 + 0.05, 40 + (i % 40), 90) for i in range(note_count)
+        ])
+
+    def test_under_cap_not_truncated(self):
+        pm = self._dense_midi(100)
+        result = call(session_with({"bass": pm}), "bass")
+        assert result["truncated"] is False
+        assert result["total_events"] == 200
+
+    def test_over_cap_truncated_and_capped(self):
+        pm = self._dense_midi(MAX_MIDI_OUT_EVENTS // 2 + 500)
+        result = call(session_with({"bass": pm}), "bass")
+        assert result["truncated"] is True
+        assert result["total_events"] <= MAX_MIDI_OUT_EVENTS
+
+    def test_truncation_keeps_earliest_notes(self):
+        pm = self._dense_midi(MAX_MIDI_OUT_EVENTS // 2 + 500)
+        result = call(session_with({"bass": pm}), "bass")
+        evs = events_of(result)
+        kept = MAX_MIDI_OUT_EVENTS // 2
+        last_kept_start = (kept - 1) * 0.1
+        assert max(e["t"] for e in evs) == pytest.approx(last_kept_start + 0.05)
+
+    def test_truncation_invariant_no_hanging_ons(self):
+        # The boundary case that matters: every emitted on has its off.
+        pm = self._dense_midi(MAX_MIDI_OUT_EVENTS // 2 + 500)
+        result = call(session_with({"bass": pm}), "bass")
+        for track in result["tracks"]:
+            sounding: set[tuple[int, int]] = set()
+            depth: dict[int, int] = {}
+            for e in track["events"]:
+                delta = 1 if e["type"] == "on" else -1
+                depth[e["note"]] = depth.get(e["note"], 0) + delta
+                assert depth[e["note"]] >= 0
+            assert all(v == 0 for v in depth.values()), "hanging note-on after truncation"
+
+    def test_truncation_spans_tracks(self):
+        # Notes dropped globally by start time, not per-track quotas.
+        pm = pretty_midi.PrettyMIDI()
+        early = pretty_midi.Instrument(program=0, name="early")
+        late = pretty_midi.Instrument(program=1, name="late")
+        half = MAX_MIDI_OUT_EVENTS // 2
+        for i in range(half):
+            early.notes.append(pretty_midi.Note(
+                velocity=90, pitch=60, start=i * 0.01, end=i * 0.01 + 0.005))
+        for i in range(500):
+            late.notes.append(pretty_midi.Note(
+                velocity=90, pitch=62, start=1000.0 + i, end=1000.5 + i))
+        pm.instruments.extend([early, late])
+        result = call(session_with(merged=pm), "merged")
+        assert result["truncated"] is True
+        # All late-track notes start after every early note — all dropped.
+        assert result["tracks"][1]["events"] == []
+        assert result["total_events"] == MAX_MIDI_OUT_EVENTS


### PR DESCRIPTION
## Summary

Adds hardware MIDI output to the MIDI tab per `docs/WEB_MIDI_OUT_SPEC.md` (rev. 2): extracted or imported MIDI stems can be streamed directly to physical synthesizers over the browser's Web MIDI API. No new dependencies on either side — the port lives on the browser's machine, the backend keeps ownership of the MIDI data.

- **`POST /api/midi/events`** — flattens a session PrettyMIDI to a JSON note-event list: zero-length notes dropped, pitch/velocity clamped (note-on floor of 1), overlapping same-pitch notes merged to abutting, off-before-on ordering at equal timestamps, truncation by whole notes at the 20 000-event cap (never an `on` without its `off`). Read-only; reuses `_resolve_midi`.
- **`frontend/components/webmidi.js`** — port discovery with hot-plug handling, a Web-Worker-driven lookahead scheduler (hidden-tab timer throttling would otherwise gap playback by seconds), and a two-phase Stop: note-offs + CC 120/123/64 sent immediately and again after the lookahead queue drains, since queued events cannot be recalled without relying on `MIDIOutput.clear()`.
- **MIDI tab UI** — left-column MIDI Out panel (availability banners, Request access, Panic across all ports/channels) and a per-card row: port/channel selects, Send/Stop with live status, multi-track merge, exclusivity per port+channel (different ports/channels play simultaneously), disconnect surfacing, and a "Send Program Change" checkbox that is off by default and suppressed for drum stems (channel 10 is never forced).
- **Persistence** — port name + channel per stem label in `localStorage` (`stemforge.midiout`), restored by port name with silent fallback to None.
- **Docs** — `INSTRUCTIONS.md` §4.2 (usage, browser support, secure-context workarounds, ALSA port contention), README feature bullet, FUTURE_PLANS deferred follow-ups (MIDI input, transport sync, pitch bend/CC, multi-port merged playback, seek).

## Testing

- `tests/test_midi_events.py` — 24 cases covering event counts, ordering, overlap merge, clamping, the truncation invariant, and 404s; wired into CI. All passing.
- Live hardware verification via CDP-driven Chrome against two connected MIDI outputs: port enumeration, playback timing (all sends inside the lookahead window), queued-tail Stop, Panic coverage (2 ports × 16 channels × 3 CCs × 2 phases), 63 s hidden-tab playback with zero late sends, same-port/channel exclusivity, concurrent playback on separate channels, multi-instrument merge ordering, Program Change on/off/drum suppression, and localStorage restore-by-name. Audible playback on hardware confirmed by the author.

## Remaining (manual, spec step 10)

Tab-close mid-playback, physical unplug/hot-plug mid-playback, the full 2+ minute hidden-tab run, and long-run listening tests for jitter under CPU load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZU62JS2N828jXRMcYby2u